### PR TITLE
Add helpers for working with bundles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,9 @@ setup(
         "pytest",
         "pyyaml",
         "juju",
-        "juju-wait",
         "charm-tools",
         "charmcraft",
+        "jinja2",
     ],
     entry_points={
         "pytest11": [

--- a/tests/test_pytest_operator.py
+++ b/tests/test_pytest_operator.py
@@ -1,24 +1,26 @@
-import asyncio
-
 from pytest_operator import OperatorTest
 
 
 class PluginTest(OperatorTest):
-    async def asyncSetUp(self):
-        self.charms = await self.build_charms(
-            "tests/data/charms/reactive-framework",
-            "tests/data/charms/operator-framework",
-        )
-        await super().asyncSetUp()
 
     async def test_build_and_deploy(self):
-        await asyncio.gather(*(self.model.deploy(charm) for charm in self.charms))
-        await self.model.block_until(
-            lambda: len(self.model.units) == 2
-            and all(
-                unit.workload_status == "active" for unit in self.model.units.values()
+        bundle = self.render_bundle(
+            """
+                series: focal
+                applications:
+                  reactive-framework:
+                    charm: {{ charms["reactive-framework"] }}
+                    num_units: 1
+                  operator-framework:
+                    charm: {{ charms["operator-framework"] }}
+                    num_units: 1
+            """,
+            charms=await self.build_charms(
+                "tests/data/charms/reactive-framework",
+                "tests/data/charms/operator-framework",
             ),
-            timeout=5 * 60,
         )
+        await self.model.deploy(bundle)
+        await self.wait_for_bundle(bundle)  # TODO: Be up-ported to libjuju
         for unit in self.model.units.values():
             assert f"{unit.name}: {unit.workload_status}".endswith("active")

--- a/tests/test_pytest_operator.py
+++ b/tests/test_pytest_operator.py
@@ -2,9 +2,12 @@ from pytest_operator import OperatorTest
 
 
 class PluginTest(OperatorTest):
-
     async def test_build_and_deploy(self):
         bundle = self.render_bundle(
+            # Normally, this would just be a filename like for the charms, rather
+            # than an in-line YAML dump, but for visibility purposes in using this
+            # test as an example, I included it directly here, since it's small. E.g.:
+            # "tests/data/bundle.yaml",
             """
                 series: focal
                 applications:

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,13 @@ envlist = lint, py3
 skipsdist=true
 
 [testenv]
-commands = pytest --tb=native -vs --ignore=tests/data {posargs:tests/test_pytest_operator.py}
+commands = pytest --tb=native -vs --ignore=tests/data {posargs}
 setenv =
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv = HOME
 deps =
      # Temporarily use these branches until PRs are merged and released to PyPI
-     https://github.com/juju/python-libjuju/archive/johnsca/465-plus-469.zip#egg=juju
+     https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
      https://github.com/juju/charm-tools/archive/update-pyyaml.zip#egg=charm-tools
      -e {toxinidir}
 


### PR DESCRIPTION
Add helpers for building multiple charms and rendering bundles using those charms and other contexts. Also includes a `wait_for_bundle` helper as a starting point for replacing `juju-wait` something built-in to libjuju.

Note: This is failing currently because there still seems to be an issue with libjuju deploying bundles which reference local `.charm` files (rather than directories).