### PR TITLE
Switch to Juju branch with fix for .charm files in bundle and up-ported helper

### DIFF
--- a/tests/test_pytest_operator.py
+++ b/tests/test_pytest_operator.py
@@ -24,6 +24,6 @@ class PluginTest(OperatorTest):
             ),
         )
         await self.model.deploy(bundle)
-        await self.wait_for_bundle(bundle)  # TODO: Be up-ported to libjuju
+        await self.model.wait_for_idle()
         for unit in self.model.units.values():
             assert f"{unit.name}: {unit.workload_status}".endswith("active")

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ setenv =
 passenv = HOME
 deps =
      # Temporarily use these branches until PRs are merged and released to PyPI
-     https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
-     https://github.com/juju/charm-tools/archive/update-pyyaml.zip#egg=charm-tools
+     https://github.com/juju/python-libjuju/archive/johnsca/bundle-charm-files-and-wait.zip#egg=juju
+     https://github.com/juju/charm-tools/archive/master.zip#egg=charm-tools
      -e {toxinidir}
 
 [testenv:lint]


### PR DESCRIPTION
[libjuju PR #470](https://github.com/juju/python-libjuju/pull/470) is still pending review, but until it lands, we can use it in the tests at least.

(Note, though, while in theory we should be able to [use `dependency_links` in `setup.py`](https://python-packaging.readthedocs.io/en/latest/dependencies.html#packages-not-on-pypi) to make the branches work on install, but for some reason when I tried that it didn't work.)