### PR TITLE
Remove workaround branches from tox and update version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,19 +36,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    - name: Install Dependencies
-      run: |
-        pip install tox
-        sudo apt-get remove -qy lxd lxd-client
-        sudo snap install core
-        sudo snap install lxd
-        sudo lxd waitready
-        sudo lxd init --auto
-        sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-        echo "/snap/bin" >> $GITHUB_PATH
-        lxc network set lxdbr0 ipv6.address none
-        sudo snap install juju --classic
-    - name: Bootstrap
-      run: juju bootstrap localhost/localhost
+    - name: Setup operator test environment
+      uses: charmed-kubernetes/actions-operator@master
     - name: Run test
       run: tox -e py3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     name="pytest-operator",
     packages=find_packages(include=["pytest_operator"]),
     url="https://github.com/charmed-kubernetes/pytest-operator",
-    version="0.1.0",
+    version="0.2.0",
     zip_safe=True,
     install_requires=[
         "asynctest ; python_version<'3.8'",

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,6 @@ setenv =
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv = HOME
 deps =
-     # Temporarily use these branches until PRs are merged and released to PyPI
-     https://github.com/juju/python-libjuju/archive/johnsca/bundle-charm-files-and-wait.zip#egg=juju
-     https://github.com/juju/charm-tools/archive/master.zip#egg=charm-tools
      -e {toxinidir}
 
 [testenv:lint]


### PR DESCRIPTION
The upstream fixes for libjuju and charm-tools have been released, so this removes the branch workarounds in the tox.ini and updates the version in setup.py for a new release.