### PR TITLE
Add logging and shorten model name

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = lint, py3
 skipsdist=true
 
 [testenv]
-commands = pytest --tb=native -vs --ignore=tests/data {posargs}
+commands = pytest --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore=tests/data {posargs}
 setenv =
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv = HOME


### PR DESCRIPTION
Add logging messages to model setup / cleanup and charm building, and shorten model name to just the class name plus a random suffix.