### PR TITLE
On test failure, dump model status and errors from Juju log

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,9 +22,6 @@ jobs:
   integration-test:
     name: Integration test with LXD
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
     timeout-minutes: 40
     steps:
     - name: Check out code
@@ -32,7 +29,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python }}
+        python-version: 3.8
     - name: Setup operator test environment
       uses: charmed-kubernetes/actions-operator@master
     - name: Run test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.charm
 venv
 build
+dist/

--- a/tests/test_pytest_operator.py
+++ b/tests/test_pytest_operator.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 
+import pytest
 from pytest_operator import OperatorTest
 
 
@@ -8,6 +9,7 @@ log = logging.getLogger(__name__)
 
 
 class PluginTest(OperatorTest):
+    @pytest.mark.abort_on_fail
     async def test_build_and_deploy(self):
         lib_path = Path(__file__).parent.parent
         pytest_operator = await self.build_lib(lib_path)


### PR DESCRIPTION
To aid in debugging failed tests, the model status will be dumped in a format similar to `juju status`, as well as the results of running `juju debug-log --replay --level=ERROR`.

Also adds a method and decorator to abort subsequent test methods if a given test method fails.