### PR TITLE
Use snaps for charm and charmcraft

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ setup(
         "pytest-asyncio",
         "pyyaml",
         "juju",
-        "charm-tools",
-        "charmcraft",
         "jinja2",
     ],
     entry_points={

--- a/tests/test_pytest_operator.py
+++ b/tests/test_pytest_operator.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 
 import pytest
@@ -54,6 +55,11 @@ class TestPlugin:
 
 async def test_func(ops_test):
     assert ops_test.model
+
+
+def test_tmp_path(ops_test):
+    tox_env_dir = Path(os.environ["TOX_ENV_DIR"]).resolve()
+    assert ops_test.tmp_path.relative_to(tox_env_dir)
 
 
 @pytest.mark.abort_on_fail(abort_on_xfail=True)

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,7 @@ setenv =
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv = HOME
 deps =
-    # Until 2.8.6 is released
-    https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
+    juju
      -e {toxinidir}
 
 [testenv:lint]


### PR DESCRIPTION
Removes PyPI dependency for `charm` and `charmcraft` tools and instead relies on them being installed at the system level, ideally as snaps.

In order to work with the confinement of the `charmcraft` snap, the temp dirs have to be relocated to live under the Tox environment temp dir. It also turns out that the `check_deps` fixture wasn't working as expected, so it was fixed, as well as the need to call `charm build` without the hyphen to support the snap.

As a bit of a drive-by, this also suppresses the DeprecationWarnings generated by libjuju which are already being [tracked there][libjuju#461].

Fixes #13
Depends on charmed-kubernetes/actions-operator#9 (the integration test will fail with a "missing dependency" error until that is merged)

[libjuju#461]: https://github.com/juju/python-libjuju/issues/461