### PR TITLE
Fix charm building for charmcraft 1.1.0

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -340,6 +340,14 @@ class OpsTest:
                 shutil.rmtree(build_path)
 
         if returncode != 0:
+            m = re.search(
+                r"Failed to build charm.*full execution logs in '([^']+)'", stderr
+            )
+            if m:
+                try:
+                    stderr = Path(m.group(1)).read_text()
+                except FileNotFoundError:
+                    log.error(f"Failed to read full build log from {m.group(1)}")
             raise RuntimeError(
                 f"Failed to build charm {charm_path}:\n{stderr}\n{stdout}"
             )

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -352,7 +352,7 @@ class OpsTest:
                 f"Failed to build charm {charm_path}:\n{stderr}\n{stdout}"
             )
 
-        return charms_dst_dir / f"{charm_name}*.charm"
+        return next(charms_dst_dir.glob(f"{charm_name}*.charm"))
 
     async def build_charms(self, *charm_paths):
         """Builds one or more charms in parallel.
@@ -365,7 +365,7 @@ class OpsTest:
         charms = await asyncio.gather(
             *(self.build_charm(charm_path) for charm_path in charm_paths)
         )
-        return {charm.stem: charm for charm in charms}
+        return {charm.stem.split("_")[0]: charm for charm in charms}
 
     def render_bundle(self, bundle, context=None, **kwcontext):
         """Render a templated bundle using Jinja2.

--- a/tests/test_pytest_operator.py
+++ b/tests/test_pytest_operator.py
@@ -22,7 +22,8 @@ class TestPlugin:
             },
         )
         req_path = charms[1] / "requirements.txt"
-        assert f"file://{pytest_operator}#egg=pytest_operator" in req_path.read_text()
+        req_text = req_path.read_text()
+        assert f"file://{pytest_operator}#egg=pytest_operator" not in req_text
         bundle = ops_test.render_bundle(
             # Normally, this would just be a filename like for the charms, rather
             # than an in-line YAML dump, but for visibility purposes in using this


### PR DESCRIPTION
Fix handling of charms built with `charmcraft` since the 1.1.0 release, which both switched to LXD containers for doing the build (leading to issues with referenced local files such as built libraries) as well as changed the name of the built `.charm` file to include info about the OS, series, and arch.

Fixes #23