### PR TITLE
Execute charmcraft build with lxd group

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,6 +31,6 @@ jobs:
       with:
         python-version: 3.8
     - name: Setup operator test environment
-      uses: charmed-kubernetes/actions-operator@master
+      uses: charmed-kubernetes/actions-operator@main
     - name: Run test
       run: tox -e py3

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -328,7 +328,7 @@ class OpsTest:
             cmd = ["charm", "build", "-F", charm_abs]
         else:
             # Handle newer, operator framework charms.
-            cmd = ["charmcraft", "build", "-f", charm_abs]
+            cmd = ["sg", "lxd", "-c", f"charmcraft build -f {charm_abs}"]
 
         log.info(f"Building charm {charm_name}")
         returncode, stdout, stderr = await self.run(*cmd, cwd=charms_dst_dir)


### PR DESCRIPTION
With the latest changes in the charmcraft snap it is required to execute charmcraft in the lxd user group.