### PR TITLE
feat: gracefully handle un-deletable files in ./build

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -146,6 +146,10 @@ async def ops_test(request, tmp_path_factory):
     await ops_test._cleanup_model()
 
 
+def handle_file_delete_error(function, path, execinfo):
+    log.warn(f"Failed to delete '{path}' due to {execinfo[1]}")
+
+
 class OpsTest:
     """Utility class for testing Operator Charms."""
 
@@ -337,7 +341,7 @@ class OpsTest:
             # Clean up build dir created by charmcraft.
             build_path = charm_path / "build"
             if build_path.exists():
-                shutil.rmtree(build_path)
+                shutil.rmtree(build_path, onerror=handle_file_delete_error)
 
         if returncode != 0:
             m = re.search(


### PR DESCRIPTION
Charmcraft occasionally can create files in `./build` that are owned by another user.  These files cause the pytest-operator to raise an exception when cleaning up `./build`.  I have not been able to make a reproducible example to post as a bug in charmcraft, but as a mitigation added a handler here to warn on the failed deletions rather than fail entirely.