### PR TITLE
Replace bespoke status with CLI call

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -251,12 +251,9 @@ class OpsTest:
 
     async def log_model(self):
         """Log a summary of the status of the model."""
-        if not (self.model.units or self.model.machines):
-            log.info("Model is empty")
-        else:
-            # TODO: Implement a pretty model status in libjuju
-            _, stdout, _ = await self.juju("status")
-            log.info(f"Model status:\n\n{stdout}")
+        # TODO: Implement a pretty model status in libjuju
+        _, stdout, _ = await self.juju("status")
+        log.info(f"Model status:\n\n{stdout}")
 
         # TODO: Implement Model.debug_log in libjuju
         _, stdout, _ = await self.juju(


### PR DESCRIPTION
The original intent was to avoid dependencies on the CLI, but due to the complexity of the work done in the CLI vs the controller and the gaps between that and libjuju, that ship has pretty much sailed. So, instead of implementing a bespoke status output which differs from what people expect, just use the CLI's existing status.