### PR TITLE
Handle more complex test directories gracefully

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -177,7 +177,7 @@ class OpsTest:
     @property
     def default_model_name(self):
         if not hasattr(self, "_default_model_name"):
-            _, _, module_name = self.request.module.__name__.rpartition(".")
+            module_name = self.request.module.__name__.rpartition(".")[-1]
             suffix = "".join(choices(ascii_lowercase + digits, k=4))
             self._default_model_name = f"{module_name.replace('_', '-')}-{suffix}"
         return self._default_model_name


### PR DESCRIPTION
More complex test structures, with nested directories, lead to model names with dots in them which are rejected by Juju.

Fixes #26
Fixes #30