### PR TITLE
Add flag for destructive mode builds

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -48,6 +48,12 @@ def pytest_addoption(parser):
         action="store_true",
         help="Keep any automatically created models",
     )
+    parser.addoption(
+        "--destructive-mode",
+        action="store_true",
+        help="Whether to run charmcraft in destructive mode "
+        "(as opposed to doing builds in lxc containers)",
+    )
 
 
 def pytest_configure(config):
@@ -161,6 +167,9 @@ class OpsTest:
 
         # Flag indicating whether all subsequent tests should be aborted.
         self.aborted = False
+
+        # Flag for using destructive mode or not for charm builds.
+        self.destructive_mode = request.config.option.destructive_mode
 
         # These may be modified by _setup_model
         self.cloud_name = request.config.option.cloud
@@ -316,6 +325,8 @@ class OpsTest:
         else:
             # Handle newer, operator framework charms.
             cmd = ["sg", "lxd", "-c", "charmcraft pack"]
+            if self.destructive_mode:
+                cmd.append("--destructive-mode")
 
         log.info(f"Building charm {charm_name}")
         returncode, stdout, stderr = await self.run(*cmd, cwd=charm_abs)

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -374,7 +374,6 @@ class OpsTest:
         self,
         bundle: Optional[str] = None,
         output_bundle: Optional[str] = None,
-        destructive_mode: bool = False,
         serial: bool = False,
     ):
         """Builds bundle using juju-bundle build."""
@@ -383,7 +382,7 @@ class OpsTest:
             cmd += ["--bundle", bundle]
         if output_bundle is not None:
             cmd += ["--output-bundle", output_bundle]
-        if destructive_mode:
+        if self.destructive_mode:
             cmd += ["--destructive-mode"]
         if serial:
             cmd += ["--serial"]
@@ -393,7 +392,6 @@ class OpsTest:
         self,
         bundle: Optional[str] = None,
         build: bool = True,
-        destructive_mode: bool = False,
         serial: bool = False,
         extra_args: Iterable[str] = (),
     ):
@@ -403,7 +401,7 @@ class OpsTest:
             cmd += ["--bundle", bundle]
         if build:
             cmd += ["--build"]
-        if destructive_mode:
+        if self.destructive_mode:
             cmd += ["--destructive-mode"]
         if serial:
             cmd += ["--serial"]

--- a/tests/test_pytest_operator.py
+++ b/tests/test_pytest_operator.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -9,6 +10,27 @@ log = logging.getLogger(__name__)
 
 
 class TestPlugin:
+    async def test_destructive_mode(self, ops_test, monkeypatch):
+        mock_run = AsyncMock(return_value=(1, "", ""))
+        monkeypatch.setattr(ops_test, "run", mock_run)
+        try:
+            await ops_test.build_charm("tests/data/charms/operator-framework")
+        except RuntimeError as e:
+            # We didn't actually build it
+            assert str(e).startswith("Failed to build charm")
+        assert mock_run.called
+        assert "--destructive-mode" not in mock_run.call_args[0]
+
+        mock_run.reset_mock()
+        ops_test.destructive_mode = True
+        try:
+            await ops_test.build_charm("tests/data/charms/operator-framework")
+        except RuntimeError as e:
+            # We didn't actually build it
+            assert str(e).startswith("Failed to build charm")
+        assert mock_run.called
+        assert "--destructive-mode" in mock_run.call_args[0]
+
     @pytest.mark.abort_on_fail
     async def test_build_and_deploy(self, ops_test):
         lib_path = Path(__file__).parent.parent


### PR DESCRIPTION
Charmcraft builds charms in LXD containers by default, but there are currently some bugs related to that and it's also less efficient if you're already running in an ephemeral environment (e.g., a GH Workflow runner). So this adds a flag to allow for skipping that by passing through the `--destructive-mode` flag.