### PR TITLE
Improve handling of lxd group management

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,21 @@ jobs:
         pip install tox
     - name: Run lint
       run: tox -e lint
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Dependencies
+      run: |
+        pip install tox
+    - name: Run unit tests
+      run: tox -e unit
   integration-test:
     name: Integration test with LXD
     runs-on: ubuntu-latest
@@ -32,5 +47,5 @@ jobs:
         python-version: 3.8
     - name: Setup operator test environment
       uses: charmed-kubernetes/actions-operator@main
-    - name: Run test
-      run: tox -e py3
+    - name: Run integration tests
+      run: tox -e integration

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -167,6 +167,7 @@ def handle_file_delete_error(function, path, execinfo):
 
 class OpsTest:
     """Utility class for testing Operator Charms."""
+
     _instance = None  # store instance so we can tell if it's been used yet
 
     def __init__(self, request, tmp_path_factory):

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -1,4 +1,5 @@
 import asyncio
+import grp
 import inspect
 import logging
 import os
@@ -81,7 +82,7 @@ def tmp_path_factory(request):
 def check_deps(*deps):
     missing = []
     for dep in deps:
-        res = subprocess.run(["which", dep])
+        res = subprocess.run(["which", dep], capture_output=True)
         if res.returncode != 0:
             missing.append(dep)
     if missing:
@@ -131,7 +132,12 @@ def pytest_runtest_makereport(item, call):
 
 
 @pytest.fixture(autouse=True)
-def abort_on_fail(request, ops_test):
+def abort_on_fail(request):
+    if OpsTest._instance is None:
+        # If we don't have an ops_test already in play, this should be a no-op.
+        yield
+        return
+    ops_test = OpsTest._instance
     if ops_test.aborted:
         pytest.xfail("aborted")
     yield
@@ -149,7 +155,9 @@ async def ops_test(request, tmp_path_factory):
     check_deps("juju", "charmcraft")
     ops_test = OpsTest(request, tmp_path_factory)
     await ops_test._setup_model()
+    OpsTest._instance = ops_test
     yield ops_test
+    OpsTest._instance = None
     await ops_test._cleanup_model()
 
 
@@ -159,6 +167,7 @@ def handle_file_delete_error(function, path, execinfo):
 
 class OpsTest:
     """Utility class for testing Operator Charms."""
+    _instance = None  # store instance so we can tell if it's been used yet
 
     def __init__(self, request, tmp_path_factory):
         self.request = request
@@ -324,9 +333,22 @@ class OpsTest:
             cmd = ["charm", "build", "--charm-file"]
         else:
             # Handle newer, operator framework charms.
-            cmd = ["sg", "lxd", "-c", "charmcraft pack"]
+            all_groups = {g.gr_name for g in grp.getgrall()}
+            users_groups = {grp.getgrgid(g).gr_name for g in os.getgroups()}
             if self.destructive_mode:
-                cmd[-1] += " --destructive-mode"
+                # host builder never requires lxd group
+                cmd = ["charmcraft", "pack", "--destructive-mode"]
+            elif "lxd" in users_groups:
+                # user already has lxd group active
+                cmd = ["charmcraft", "pack"]
+            else:
+                # building with lxd builder and user does't already have lxd group;
+                # make sure it's available and if so, try using `sg` to acquire it
+                assert "lxd" in all_groups, (
+                    "Group 'lxd' required but not available; "
+                    "ensure that lxd is available or use --destructive-mode"
+                )
+                cmd = ["sg", "lxd", "-c", "charmcraft pack"]
 
         log.info(f"Building charm {charm_name}")
         returncode, stdout, stderr = await self.run(*cmd, cwd=charm_abs)

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -1,7 +1,6 @@
 import logging
 import os
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -10,30 +9,9 @@ log = logging.getLogger(__name__)
 
 
 class TestPlugin:
-    async def test_destructive_mode(self, ops_test, monkeypatch):
-        mock_run = AsyncMock(return_value=(1, "", ""))
-        monkeypatch.setattr(ops_test, "run", mock_run)
-        try:
-            await ops_test.build_charm("tests/data/charms/operator-framework")
-        except RuntimeError as e:
-            # We didn't actually build it
-            assert str(e).startswith("Failed to build charm")
-        assert mock_run.called
-        assert mock_run.call_args[0][-1] == "charmcraft pack"
-
-        mock_run.reset_mock()
-        ops_test.destructive_mode = True
-        try:
-            await ops_test.build_charm("tests/data/charms/operator-framework")
-        except RuntimeError as e:
-            # We didn't actually build it
-            assert str(e).startswith("Failed to build charm")
-        assert mock_run.called
-        assert mock_run.call_args[0][-1] == "charmcraft pack --destructive-mode"
-
     @pytest.mark.abort_on_fail
     async def test_build_and_deploy(self, ops_test):
-        lib_path = Path(__file__).parent.parent
+        lib_path = Path(__file__).parent.parent.parent
         pytest_operator = await ops_test.build_lib(lib_path)
         charms = ops_test.render_charms(
             "tests/data/charms/reactive-framework",

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -1,0 +1,52 @@
+from unittest.mock import Mock, AsyncMock, ANY
+
+import pytest
+
+from pytest_operator import plugin
+
+
+async def test_destructive_mode(monkeypatch, tmp_path_factory):
+    patch = monkeypatch.setattr
+    patch(plugin.os, "getgroups", mock_getgroups := Mock(return_value=[]))
+    patch(plugin.grp, "getgrall", mock_getgrall := Mock(return_value=[]))
+    patch(plugin.grp, "getgrgid", Mock(return_value=Mock(gr_name="lxd")))
+    patch(plugin.OpsTest, "run", mock_run := AsyncMock(return_value=(1, "", "")))
+    ops_test = plugin.OpsTest(Mock(**{"module.__name__": "test"}), tmp_path_factory)
+
+    ops_test.destructive_mode = True
+    try:
+        await ops_test.build_charm("tests/data/charms/operator-framework")
+    except RuntimeError as e:
+        # We didn't actually build it
+        assert str(e).startswith("Failed to build charm")
+    assert mock_run.called
+    assert mock_run.call_args[0] == ("charmcraft", "pack", "--destructive-mode")
+
+    mock_run.reset_mock()
+    ops_test.destructive_mode = False
+    try:
+        await ops_test.build_charm("tests/data/charms/operator-framework")
+    except AssertionError as e:
+        # Expected failure
+        assert str(e).startswith("Group 'lxd' required")
+    else:
+        pytest.fail("Missing expected lxd group assertion")
+    assert not mock_run.called
+
+    mock_getgrall.return_value = [Mock(gr_name="lxd")]
+    try:
+        await ops_test.build_charm("tests/data/charms/operator-framework")
+    except RuntimeError as e:
+        # We didn't actually build it
+        assert str(e).startswith("Failed to build charm")
+    assert mock_run.called
+    assert mock_run.call_args[0] == ("sg", "lxd", "-c", "charmcraft pack")
+
+    mock_getgroups.return_value = [ANY]
+    try:
+        await ops_test.build_charm("tests/data/charms/operator-framework")
+    except RuntimeError as e:
+        # We didn't actually build it
+        assert str(e).startswith("Failed to build charm")
+    assert mock_run.called
+    assert mock_run.call_args[0] == ("charmcraft", "pack")

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,11 @@
 [tox]
-envlist = lint, py3
+envlist = lint, unit
 skipsdist=true
 
 [testenv]
-commands = pytest --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore=tests/data {posargs}
 setenv =
     PYTHONBREAKPOINT=ipdb.set_trace
 passenv = HOME
-deps =
-    juju
-     -e {toxinidir}
 
 [testenv:lint]
 commands =
@@ -25,6 +21,18 @@ commands =
 deps =
      flake8
      black
+
+[testenv:unit]
+commands = pytest --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore=tests/data {posargs:tests/unit}
+deps =
+     -e {toxinidir}
+
+[testenv:integration]
+passenv = HOME
+commands = pytest --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore=tests/data {posargs:tests/integration}
+deps =
+    juju
+     -e {toxinidir}
 
 [flake8]
 max-line-length: 88

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ passenv = HOME
 
 [testenv:lint]
 commands =
-     flake8 pytest_operator tests/test_pytest_operator.py
-     black --check pytest_operator tests/test_pytest_operator.py
+     flake8 pytest_operator tests/unit tests/integration
+     black --check pytest_operator tests/unit tests/integration
 deps =
      flake8
      black


### PR DESCRIPTION
When using destructive mode, or if the user is already a member of the lxd group, then using `sg` to gain the group is unnecessary and can sometimes lead to issues. Even when needed, if the group is not available, the error message produced is confusing.

This also refactors the tests into separate unit and integration tests, and updates the `abort_on_fail` autouse fixture to avoid creating an `ops_test` instance (and thus creating a model) when not needed.