### PR TITLE
Fix failure to build operator-framework test charm

### DIFF
--- a/tests/data/charms/operator-framework/charmcraft.yaml
+++ b/tests/data/charms/operator-framework/charmcraft.yaml
@@ -1,0 +1,8 @@
+type: charm
+parts:
+  charm:
+    # updated setuptools needed to install jinja2 dependency
+    charm-python-packages: [setuptools]
+bases:
+- name: "ubuntu"
+  channel: "20.04"

--- a/tests/data/charms/operator-framework/charmcraft.yaml
+++ b/tests/data/charms/operator-framework/charmcraft.yaml
@@ -2,9 +2,11 @@ type: charm
 parts:
   charm:
     charm-python-packages:
-      - setuptools  # needed to install jinja2
+      - setuptools  # for jinja2
     build-packages:
-      - libffi-dev  # needed to install cffi brought in by juju
+      - libffi-dev  # for cffi
+      - libssl-dev  # for cryptography
+      - rust-all    # for cryptography
 bases:
 - name: "ubuntu"
   channel: "20.04"

--- a/tests/data/charms/operator-framework/charmcraft.yaml
+++ b/tests/data/charms/operator-framework/charmcraft.yaml
@@ -1,8 +1,10 @@
 type: charm
 parts:
   charm:
-    # updated setuptools needed to install jinja2 dependency
-    charm-python-packages: [setuptools]
+    charm-python-packages:
+      - setuptools  # needed to install jinja2
+    build-packages:
+      - libffi-dev  # needed to install cffi brought in by juju
 bases:
 - name: "ubuntu"
   channel: "20.04"


### PR DESCRIPTION
Per https://github.com/canonical/charmcraft/issues/551 and https://discourse.charmhub.io/t/install-or-update-python-packages-before-packing-a-charm/5158, we need charmcraft to update setuptools before installing the rest of the requirements in order to prevent a failure during the install of jinja2.