### PR TITLE
Add crash-dump option to generate juju-crashdump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ venv
 build
 dist/
 *.orig
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 build
 dist/
 *.orig
+.idea

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -73,6 +73,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--crash-dump-output",
         action="store",
+        default=None,
         help="Store the completed crash dump in this dir. "
         "The default is current folder.",
     )

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -55,21 +55,14 @@ class TestPlugin:
 
     async def test_1_create_crash_dump(self, ops_test):
         """Check if juju-crashdump was called."""
-        lib_path = Path(__file__).parent.parent.parent
-        user_crashdumps = set(lib_path.glob("juju-crashdump-*.tar.xz"))
-
+        # configure juju-crashdump output directory to pytest-operator tmp directory
+        ops_test.crash_dump_output = ops_test.tmp_path
         created = await ops_test.create_crash_dump()
         if not created:
-            pytest.xfail("juju-crashdump command is was not found")
+            pytest.xfail("juju-crashdump command was not found")
 
-        crashdumps = set(lib_path.glob("juju-crashdump-*.tar.xz")).difference(
-            user_crashdumps
-        )
+        crashdumps = set(ops_test.tmp_path.glob("juju-crashdump-*.tar.xz"))
         assert len(crashdumps) > 0, "no crash dump was found"
-
-        # clean crashdump from this test
-        for crash_dump in crashdumps:
-            crash_dump.unlink()
 
 
 async def test_func(ops_test):

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -53,6 +53,24 @@ class TestPlugin:
             "operator-framework",
         }
 
+    async def test_1_create_crash_dump(self, ops_test):
+        """Check if juju-crashdump was called."""
+        lib_path = Path(__file__).parent.parent.parent
+        user_crashdumps = set(lib_path.glob("juju-crashdump-*.tar.xz"))
+
+        created = await ops_test.create_crash_dump()
+        if not created:
+            pytest.xfail("juju-crashdump command is was not found")
+
+        crashdumps = set(lib_path.glob("juju-crashdump-*.tar.xz")).difference(
+            user_crashdumps
+        )
+        assert len(crashdumps) > 0, "no crash dump was found"
+
+        # clean crashdump from this test
+        for crash_dump in crashdumps:
+            crash_dump.unlink()
+
 
 async def test_func(ops_test):
     assert ops_test.model

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -1,4 +1,6 @@
-from unittest.mock import Mock, AsyncMock, ANY
+import asyncio
+import pathlib
+from unittest.mock import Mock, AsyncMock, ANY, MagicMock
 
 import pytest
 
@@ -50,3 +52,77 @@ async def test_destructive_mode(monkeypatch, tmp_path_factory):
         assert str(e).startswith("Failed to build charm")
     assert mock_run.called
     assert mock_run.call_args[0] == ("charmcraft", "pack")
+
+
+async def test_crash_dump_mode(monkeypatch, tmp_path_factory):
+    """Test running juju-crashdump in OpsTest.cleanup."""
+    patch = monkeypatch.setattr
+    patch(plugin.OpsTest, "run", mock_run := AsyncMock(return_value=(0, "", "")))
+    ops_test = plugin.OpsTest(
+        mock_request := Mock(**{"module.__name__": "test"}), tmp_path_factory
+    )
+    ops_test.crash_dump = True
+    ops_test.keep_model = False
+    ops_test.model = MagicMock()
+    ops_test.model.machines.values.return_value = []
+    ops_test.model.disconnect = AsyncMock()
+    ops_test.model_full_name = "test-model"
+    ops_test.log_model = AsyncMock()
+    ops_test._controller = AsyncMock()
+
+    # 0 tests failed
+    mock_request.session.testsfailed = 0
+
+    await ops_test._cleanup_model()
+
+    mock_run.assert_not_called()
+    mock_run.reset_mock()
+
+    # 1 tests failed
+    mock_request.session.testsfailed = 1
+
+    await ops_test._cleanup_model()
+
+    mock_run.assert_called_once_with(
+        "juju-crashdump",
+        "-s",
+        "-m",
+        "test-model",
+        "-a",
+        "debug-layer",
+        "-a",
+        "config",
+        "-o",
+        plugin._source_charm_dir(ops_test.tmp_path),
+    )
+    mock_run.reset_mock()
+
+
+async def test_create_crash_dump(monkeypatch, tmp_path_factory):
+    """Test running create crash dump."""
+
+    async def mock_run(*cmd):
+        proc = await asyncio.create_subprocess_exec("not-valid-command")
+        await proc.communicate()
+
+    patch = monkeypatch.setattr
+    patch(plugin.OpsTest, "run", mock_run)
+    patch(plugin, "log", mock_log := MagicMock())
+    ops_test = plugin.OpsTest(Mock(**{"module.__name__": "test"}), tmp_path_factory)
+    await ops_test.create_crash_dump()
+    mock_log.info.assert_any_call("juju-crashdump command was not found.")
+
+
+@pytest.mark.parametrize(
+    "path, exp_source_path",
+    [
+        (pathlib.Path("/test/.tox/a/b/c/d"), pathlib.Path("/test")),
+        (pathlib.Path("/test/a/b/c/d/.tox/a/b/c/d"), pathlib.Path("/test/a/b/c/d")),
+        (pathlib.Path("/test/a/b/c/d"), None),
+    ],
+)
+def test_source_charm_dir(path, exp_source_path):
+    """Test getting source charm dir."""
+    assert (
+        plugin._source_charm_dir(path) == exp_source_path
+    ), "the path {} does not contain {}".format(path, exp_source_path)

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -1,5 +1,4 @@
 import asyncio
-import pathlib
 from unittest.mock import Mock, AsyncMock, ANY, MagicMock
 
 import pytest
@@ -67,6 +66,7 @@ async def test_crash_dump_mode(monkeypatch, tmp_path_factory):
     ops_test.model.machines.values.return_value = []
     ops_test.model.disconnect = AsyncMock()
     ops_test.model_full_name = "test-model"
+    ops_test.crash_dump_output = None
     ops_test.log_model = AsyncMock()
     ops_test._controller = AsyncMock()
 
@@ -92,8 +92,6 @@ async def test_crash_dump_mode(monkeypatch, tmp_path_factory):
         "debug-layer",
         "-a",
         "config",
-        "-o",
-        plugin._source_charm_dir(ops_test.tmp_path),
     )
     mock_run.reset_mock()
 
@@ -111,18 +109,3 @@ async def test_create_crash_dump(monkeypatch, tmp_path_factory):
     ops_test = plugin.OpsTest(Mock(**{"module.__name__": "test"}), tmp_path_factory)
     await ops_test.create_crash_dump()
     mock_log.info.assert_any_call("juju-crashdump command was not found.")
-
-
-@pytest.mark.parametrize(
-    "path, exp_source_path",
-    [
-        (pathlib.Path("/test/.tox/a/b/c/d"), pathlib.Path("/test")),
-        (pathlib.Path("/test/a/b/c/d/.tox/a/b/c/d"), pathlib.Path("/test/a/b/c/d")),
-        (pathlib.Path("/test/a/b/c/d"), None),
-    ],
-)
-def test_source_charm_dir(path, exp_source_path):
-    """Test getting source charm dir."""
-    assert (
-        plugin._source_charm_dir(path) == exp_source_path
-    ), "the path {} does not contain {}".format(path, exp_source_path)

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,3 @@ deps =
 
 [flake8]
 max-line-length: 88
-
-[pytest]
-asyncio_mode=auto

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
 
 [testenv:reformat]
 commands =
-     black pytest_operator tests/test_pytest_operator.py
+     black pytest_operator tests/integration/test_pytest_operator.py tests/unit/test_pytest_operator.py
 deps =
      flake8
      black
@@ -36,3 +36,6 @@ deps =
 
 [flake8]
 max-line-length: 88
+
+[pytest]
+asyncio_mode=auto


### PR DESCRIPTION
- add crash-dump option
- add function to trigger `juju-crashdump` if command is available
- fix deprecation warnings around pytest
- add unit and integration tests