### PR TITLE
feat: Add log message to deploy_bundle

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -735,6 +735,11 @@ class OpsTest:
             cmd += ["--serial"]
 
         cmd += ["--", "-m", self.model_name] + list(extra_args)
+
+        log.info(
+            "Deploying (and possibly building) bundle using juju-bundle command:"
+            f"'{' '.join(cmd)}'"
+        )
         await self.run(*cmd, check=True)
 
     def render_bundle(self, bundle, context=None, **kwcontext):


### PR DESCRIPTION
Adds a log message so it is clear that the operator is building/deploying a bundle.  

This came up when debugging a charm where CI appeared to hang on 
```
INFO     pytest_operator.plugin:plugin.py:440 Connecting to model uk8sx:kubeflow
```
when actually it had successfully connected to the model and instead silently got stuck in a `deploy_bundle()` call.  This message adds clarity for those situations.  