### PR TITLE
Adding option --no-deploy

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,6 +27,12 @@ Path to a yaml file which will be applied to the model on creation.
  * ignored if `--model` supplied 
  * if the specified file doesn't exist, an error will be raised.
 
+### `--no-deploy`
+
+Flag that guarantees skipping the function marked with `skip_if_deployed`. The skip will
+only work if the `--model` parameter is also provided. 
+
+
 ## Fixtures
 
 ### `ops_test`
@@ -64,6 +70,21 @@ initial build and deploy.
 This marker from pytest-asyncio is automatically applied to any `async` test function
 which is collected, so that you don't have to decorate every single one of your tests
 with it.
+
+### `@pytest.mark.skip_if_deployed`
+
+This marker should be used for test_build_and_deploy functions, ie functions that have
+the job of building a charm and then deploying it alone or in a bundle. It will ensure
+that the function can be skipped using the `--no-deploy` parameter, which will help the
+developer to run integration tests multiple times.
+
+---
+**NOTE**
+
+Using the `skip_if_deployed` and` --no-deploy` parameters will not ensure build and
+subsequent refresh of the charm.
+
+---
 
 
 ## Warning Filters

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -82,7 +82,7 @@ def pytest_addoption(parser):
         "--no-deploy",
         action="store_true",
         help="This, together with the `--model` parameter, ensures that all functions "
-             "marked with the` skip_if_deployed` tag are skipped."
+        "marked with the` skip_if_deployed` tag are skipped.",
     )
     parser.addoption(
         "--model-config",

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -81,8 +81,8 @@ def pytest_addoption(parser):
     parser.addoption(
         "--no-deploy",
         action="store_true",
-        help="Skip deployment. This will skip all functions marked with "
-        "`abort_on_fail` marker..",
+        help="This, together with the `--model` parameter, ensures that all functions "
+             "marked with the` skip_if_deployed` tag are skipped."
     )
     parser.addoption(
         "--model-config",
@@ -96,6 +96,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "abort_on_fail")
+    config.addinivalue_line("markers", "skip_if_deployed")
     # These need to be fixed in libjuju and just clutter things up for tests using this.
     config.addinivalue_line(
         "filterwarnings", "ignore:The loop argument:DeprecationWarning"
@@ -106,14 +107,12 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    # This will prevent the model from being deployed again. Skips all functions marked
-    # with the abort_on_fail marker.
     if (
-        "abort_on_fail" in item.keywords
+        "skip_if_deployed" in item.keywords
         and item.config.getoption("--no-deploy")
         and item.config.getoption("--model") is not None
     ):
-        pytest.skip("Skipping deployment.")
+        pytest.skip("Skipping deployment because --no-deploy was specified.")
 
 
 @pytest.fixture(scope="session")

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -92,6 +92,10 @@ def pytest_addoption(parser):
         "* ignored if `--model` supplied"
         "* if the specified file doesn't exist, an error will be raised.",
     )
+    arg_parser = parser._getparser()
+    args = arg_parser.parse_args()
+    if args.no_deploy and args.model is None:
+        arg_parser.error("must specify --model when using --no-deploy")
 
 
 def pytest_configure(config):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["pytester"]

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -291,3 +291,33 @@ async def test_create_crash_dump(monkeypatch, tmp_path_factory):
     ops_test = plugin.OpsTest(Mock(**{"module.__name__": "test"}), tmp_path_factory)
     await ops_test.create_crash_dump()
     mock_log.info.assert_any_call("juju-crashdump command was not found.")
+
+
+def test_no_deploy_mode(testdir):
+    """Test running no deploy mode."""
+    testdir.makepyfile(
+        """
+        import pytest
+
+        def test_01():
+            pass
+
+        @pytest.mark.abort_on_fail
+        def test_build_and_deploy():
+            pass
+
+        def test_02():
+            pass
+    """
+    )
+    # test without --no-deploy option
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=3)
+
+    # test with --no-deploy, but without --model option
+    result = testdir.runpytest("--no-deploy")
+    result.assert_outcomes(passed=3)
+
+    # test with --no-deploy and --model
+    result = testdir.runpytest("--no-deploy", "--model", "test-model")
+    result.assert_outcomes(passed=2, skipped=1)

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -299,11 +299,12 @@ def test_no_deploy_mode(testdir):
         """
         import pytest
 
-        def test_01():
+        @pytest.mark.abort_on_fail
+        @pytest.mark.skip_if_deployed
+        def test_build_and_deploy():
             pass
 
-        @pytest.mark.abort_on_fail
-        def test_build_and_deploy():
+        def test_01():
             pass
 
         def test_02():

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -293,9 +293,9 @@ async def test_create_crash_dump(monkeypatch, tmp_path_factory):
     mock_log.info.assert_any_call("juju-crashdump command was not found.")
 
 
-def test_no_deploy_mode(testdir):
+def test_no_deploy_mode(pytester):
     """Test running no deploy mode."""
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         import pytest
 
@@ -312,13 +312,17 @@ def test_no_deploy_mode(testdir):
     """
     )
     # test without --no-deploy option
-    result = testdir.runpytest()
+    result = pytester.runpytest_subprocess()
     result.assert_outcomes(passed=3)
 
     # test with --no-deploy, but without --model option
-    result = testdir.runpytest("--no-deploy")
-    result.assert_outcomes(passed=3)
+    result = pytester.runpytest_subprocess("--no-deploy")
+    assert any(
+        "error: must specify --model when using --no-deploy" in errline
+        for errline in result.errlines
+    )
+    assert result.outlines == []
 
     # test with --no-deploy and --model
-    result = testdir.runpytest("--no-deploy", "--model", "test-model")
+    result = pytester.runpytest_subprocess("--no-deploy", "--model", "test-model")
     result.assert_outcomes(passed=2, skipped=1)


### PR DESCRIPTION
This will allow you to skip all functions marked with the `abort_on_fail`
marker, which represents bundle/charm deployment.