### PR TITLE
Updated docs for `--crash-dump` and `--crash-dump-output` parameter

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -32,11 +32,10 @@ Path to a yaml file which will be applied to the model on creation.
 Flag that guarantees skipping the function marked with `skip_if_deployed`. The skip will
 only work if the `--model` parameter is also provided. 
 
-### `--crash-dump` and `--no-crash-dump`
+### `--no-crash-dump`
 
-This flag enabling automatically running `juju-crashdump` (if a command is available)
-after unsuccessful tests. It's enabled by default and can be disabled with 
-`--no-crash-dump` flag. 
+This flag disables the automatic execution of `juju-crashdump`, which runs by default
+(if a command is available) after failed tests.
 
 ### `--crash-dump-output`
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -32,6 +32,17 @@ Path to a yaml file which will be applied to the model on creation.
 Flag that guarantees skipping the function marked with `skip_if_deployed`. The skip will
 only work if the `--model` parameter is also provided. 
 
+### `--crash-dump` and `--no-crash-dump`
+
+This flag enabling automatically running `juju-crashdump` (if a command is available)
+after unsuccessful tests. It's enabled by default and can be disabled with 
+`--no-crash-dump` flag. 
+
+### `--crash-dump-output`
+
+Path to the directory where the `juju-crashdump` output will be stored. The default is
+the current working directory.
+
 
 ## Fixtures
 

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 import grp
 import inspect
@@ -66,17 +67,17 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--crash-dump",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Whether to run juju-crashdump after failed tests. "
-        "This is enabled by default.",
+        "This is enabled by default and can be disabled with `--no-crash-dump` flag.",
     )
     parser.addoption(
         "--crash-dump-output",
         action="store",
         default=None,
         help="Store the completed crash dump in this dir. "
-        "The default is current folder.",
+        "The default is current working directory.",
     )
     parser.addoption(
         "--no-deploy",

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -1,4 +1,3 @@
-import argparse
 import asyncio
 import grp
 import inspect
@@ -66,11 +65,10 @@ def pytest_addoption(parser):
         "(as opposed to doing builds in lxc containers)",
     )
     parser.addoption(
-        "--crash-dump",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Whether to run juju-crashdump after failed tests. "
-        "This is enabled by default and can be disabled with `--no-crash-dump` flag.",
+        "--no-crash-dump",
+        action="store_true",
+        help="Disabled automatic runs of juju-crashdump after failed tests, "
+        "juju-crashdump runs by default.",
     )
     parser.addoption(
         "--crash-dump-output",
@@ -368,7 +366,7 @@ class OpsTest:
         self.model_config = request.config.option.model_config
 
         # Flag for enabling the juju-crashdump
-        self.crash_dump = request.config.option.crash_dump
+        self.crash_dump = not request.config.option.no_crash_dump
         self.crash_dump_output = request.config.option.crash_dump_output
 
         # These will be set by _setup_model

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -58,9 +58,7 @@ class TestPlugin:
         # configure juju-crashdump output directory to pytest-operator tmp directory
         ops_test.crash_dump_output = ops_test.tmp_path
         created = await ops_test.create_crash_dump()
-        if not created:
-            pytest.xfail("juju-crashdump command was not found")
-
+        assert created, "juju-crashdump was not created"
         crashdumps = set(ops_test.tmp_path.glob("juju-crashdump-*.tar.xz"))
         assert len(crashdumps) > 0, "no crash dump was found"
 


### PR DESCRIPTION
I forgot to add the `--no-crash-dump` and `--crash-dump-output` parameters to the documentation.

I've also fixed the ability to disable running `juju-crashdump` with the `--no-crash-dump` parameter. 