### PR TITLE
Replace build pytest_operator with test_lib

### DIFF
--- a/tests/data/charms/operator-framework/charmcraft.yaml
+++ b/tests/data/charms/operator-framework/charmcraft.yaml
@@ -1,12 +1,4 @@
 type: charm
-parts:
-  charm:
-    charm-python-packages:
-      - setuptools  # for jinja2
-    build-packages:
-      - libffi-dev  # for cffi
-      - libssl-dev  # for cryptography
-      - rust-all    # for cryptography
 bases:
 - name: "ubuntu"
   channel: "20.04"

--- a/tests/data/charms/operator-framework/requirements.txt
+++ b/tests/data/charms/operator-framework/requirements.txt
@@ -1,2 +1,2 @@
 ops
-file://{{ pytest_operator }}#egg=pytest_operator
+file://{{ pytest_operator_test_lib }}#egg=pytest-operator-test-lib

--- a/tests/data/test_lib/setup.py
+++ b/tests/data/test_lib/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(
+      name="pytest-operator-test-lib",
+      version="1.0.0",
+      description="Pytest-operator test library.",
+      author="tester",
+      packages=[],
+)

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -11,19 +11,19 @@ log = logging.getLogger(__name__)
 class TestPlugin:
     @pytest.mark.abort_on_fail
     async def test_build_and_deploy(self, ops_test):
-        lib_path = Path(__file__).parent.parent.parent
-        pytest_operator = await ops_test.build_lib(lib_path)
+        lib_path = Path(__file__).parent.parent / "data" / "test_lib"
+        test_lib = await ops_test.build_lib(lib_path)
         charms = ops_test.render_charms(
             "tests/data/charms/reactive-framework",
             "tests/data/charms/operator-framework",
             include=["requirements.txt"],
             context={
-                "pytest_operator": pytest_operator,
+                "pytest_operator_test_lib": test_lib,
             },
         )
         req_path = charms[1] / "requirements.txt"
         req_text = req_path.read_text()
-        assert f"file://{pytest_operator}#egg=pytest_operator" not in req_text
+        assert f"file://{test_lib}#egg=pytest-operator-test-lib" not in req_text
         bundle = ops_test.render_bundle(
             # Normally, this would just be a filename like for the charms, rather
             # than an in-line YAML dump, but for visibility purposes in using this


### PR DESCRIPTION
Use dumb test-lib instead of building pytest_operator as a library in
integration test. This will reduce the time of integration tests.