### PR TITLE
fix: clarify language in build_charm logging

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -587,8 +587,10 @@ class OpsTest:
         if returncode == 0:
             log.info(f"Built charm {charm_name} in {elapsed:.2f}s")
         else:
-            log.info(f"Charm build for {charm_name} completed with errors (return "
-                     f"code={returncode}) in {elapsed:.2f}s")
+            log.info(
+                f"Charm build for {charm_name} completed with errors (return "
+                f"code={returncode}) in {elapsed:.2f}s"
+            )
 
         if not layer_path.exists():
             # Clean up build dir created by charmcraft.

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -584,7 +584,11 @@ class OpsTest:
         start = timer()
         returncode, stdout, stderr = await self.run(*cmd, cwd=charm_abs)
         elapsed = timer() - start
-        log.info(f"Built charm {charm_name} in {elapsed:.2f}s")
+        if returncode == 0:
+            log.info(f"Built charm {charm_name} in {elapsed:.2f}s")
+        else:
+            log.info(f"Charm build for {charm_name} completed with errors (return code={returncode}) "
+                     f"in {elapsed:.2f}s")
 
         if not layer_path.exists():
             # Clean up build dir created by charmcraft.

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -587,8 +587,8 @@ class OpsTest:
         if returncode == 0:
             log.info(f"Built charm {charm_name} in {elapsed:.2f}s")
         else:
-            log.info(f"Charm build for {charm_name} completed with errors (return code={returncode}) "
-                     f"in {elapsed:.2f}s")
+            log.info(f"Charm build for {charm_name} completed with errors (return "
+                     f"code={returncode}) in {elapsed:.2f}s")
 
         if not layer_path.exists():
             # Clean up build dir created by charmcraft.


### PR DESCRIPTION
This sets more explicit language for the log message emitted by `build_charm`.  Previously, if a charm build failed the user would see a message like:

```
    INFO     pytest_operator.plugin:plugin.py:591 Charm build for minio completed with return code 1 in 47.04s
    FAILED
```

This could be ambiguous as it implies the build succeeded in X seconds, when instead it finished (with error) in X seconds.  This commit clarifies that language