### PR TITLE
Reintroduce 'DeadEntityException' allowance 

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -824,14 +824,14 @@ class OpsTest:
     @staticmethod
     async def _reset(model: Model, allow_failure, timeout: Optional[int] = None):
         # Forcibly destroy applications/machines in case any units are in error.
-        async def _destroy(entity: str, **kwargs):
-            for key, entity in getattr(model, entity).items():
+        async def _destroy(entity_name: str, **kwargs):
+            for key, entity in getattr(model, entity_name).items():
                 try:
-                    log.info(f"   Destroying {entity} {key}")
+                    log.info(f"   Destroying {entity_name} {key}")
                     await entity.destroy(**kwargs)
                 except DeadEntityException as e:
                     log.warning(e)
-                    log.warning(f"{entity.title()} already dead, skipping")
+                    log.warning(f"{entity_name.title()} already dead, skipping")
                 except JujuError as e:
                     log.exception(e)
                     if not allow_failure:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     name="pytest-operator",
     packages=find_packages(include=["pytest_operator"]),
     url="https://github.com/charmed-kubernetes/pytest-operator",
-    version="0.18.0",
+    version="0.19.0",
     zip_safe=True,
     install_requires=[
         "ipdb",

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,10 @@ commands = pytest \
 
 [testenv:integration]
 passenv = HOME
-commands = pytest --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore=tests/data --model-config tests/data/model-config.yaml {posargs:tests/integration}
+commands =
+    pytest --tb=native --show-capture=no --log-cli-level=INFO\
+           -vs --ignore=tests/data --ignore=tests/unit \
+           --model-config tests/data/model-config.yaml {posargs:tests/integration}
 deps =
     juju
      -e {toxinidir}


### PR DESCRIPTION
when tearing down machines which may already be gone from libjuju model, a `DeadEntityException` can be raised by libjuju.  These are safely ignore-able in this situation