### PR TITLE
Fast forward util

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -248,6 +248,23 @@ Runs a Juju CLI command.
 Useful for cases where python-libjuju sees things differently than the Juju CLI. Will set
 `JUJU_MODEL`, so manually passing in `-m model-name` is unnecessary.
 
+#### `async def fast_forward(self, fast_interval: str = "10s", slow_interval: Optional[str] = None)`
+
+Temporarily speed up update-status firing rate for the current model.
+Returns an async context manager that temporarily sets update-status firing rate to `fast_interval`.
+If provided, when the context exits the update-status firing rate will be set to `slow_interval`. Otherwise, it will be set to the previous value.
+
+* If `fast_interval` is provided, the update-status firing rate will be set to that value upon entering the context. Default is 10s.
+* If `slow_interval` is provided, after the context exits the update-status firing rate will be set to that value; otherwise, to the value it had before the context was entered.
+
+It is effectively a shortcut for:
+```python
+    await ops_test.model.set_config({"update-status-hook-interval": <fast-interval>})
+
+    # do something
+
+    await ops_test.model.set_config({"update-status-hook-interval": <slow-interval>})
+```
 
 #### `def abort(self, *args, **kwargs)`
 

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -129,21 +129,25 @@ async def test_run(ops_test):
     assert await ops_test.run("/usr/bin/rev", stdin=stdin) == (0, revd, "")
 
 
-@pytest.mark.parametrize("fast_interval, slow_interval", (
-        ('10s', None),
-        ('10s', '10m'),
-        ('42s', '42m'),
-        ('41m', '41s'),  # odd but... why not.
-        ('43s', None),
-
-))
+@pytest.mark.parametrize(
+    "fast_interval, slow_interval",
+    (
+        ("10s", None),
+        ("10s", "10m"),
+        ("42s", "42m"),
+        ("41m", "41s"),  # odd but... why not.
+        ("43s", None),
+    ),
+)
 async def test_fast_forward(ops_test: OpsTest, fast_interval, slow_interval):
     async def _get_rate():
-        return (await ops_test.model.get_config())['update-status-hook-interval']
+        return (await ops_test.model.get_config())["update-status-hook-interval"].value
 
     previous_rate = await _get_rate()
 
-    async with ops_test.fast_forward(fast_interval=fast_interval, slow_interval=slow_interval):
+    async with ops_test.fast_forward(
+        fast_interval=fast_interval, slow_interval=slow_interval
+    ):
         assert await _get_rate() == fast_interval
 
     assert await _get_rate() == slow_interval or previous_rate

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from pytest_operator.plugin import OpsTest
+
 log = logging.getLogger(__name__)
 
 
@@ -125,6 +127,26 @@ async def test_run(ops_test):
 
     stdin, revd = b"hello world", "dlrow olleh"
     assert await ops_test.run("/usr/bin/rev", stdin=stdin) == (0, revd, "")
+
+
+@pytest.mark.parametrize("fast_interval, slow_interval", (
+        ('10s', None),
+        ('10s', '10m'),
+        ('42s', '42m'),
+        ('41m', '41s'),  # odd but... why not.
+        ('43s', None),
+
+))
+async def test_fast_forward(ops_test: OpsTest, fast_interval, slow_interval):
+    async def _get_rate():
+        return (await ops_test.model.get_config())['update-status-hook-interval']
+
+    previous_rate = await _get_rate()
+
+    async with ops_test.fast_forward(fast_interval=fast_interval, slow_interval=slow_interval):
+        assert await _get_rate() == fast_interval
+
+    assert await _get_rate() == slow_interval or previous_rate
 
 
 @pytest.mark.abort_on_fail(abort_on_xfail=True)


### PR DESCRIPTION
added a utility to OpsTest to temporarily set "update-status-hook-interval" to a given value, and then set it back to whatever it was before (or another 'slow' value).

Solves #78