### PR TITLE
Add py.typed marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     keywords=["pytest", "py.test", "operators", "yaml", "asyncio"],
     name="pytest-operator",
     packages=find_packages(include=["pytest_operator"]),
+    package_data={'pytest_operator': ['py.typed']},
     url="https://github.com/charmed-kubernetes/pytest-operator",
     version="0.21.0",
     zip_safe=True,


### PR DESCRIPTION
When running static checks, mypy complains:

```
tests/integration/test_bundle.py:37: error: Skipping analyzing "pytest_operator": module is installed, but missing library stubs or py.typed marker  [import]
    from pytest_operator import plugin
    ^
```

Error goes away after introducing the py.typed marker.

Ref: [Mypy docs for PEP-516](https://mypy.readthedocs.io/en/latest/installed_packages.html#creating-pep-561-compatible-packages)