### PR TITLE
Increase static check usability by raising instead of returning None [WIP]

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -511,10 +511,12 @@ class OpsTest:
         return current_state.config if current_state else None
 
     @property
-    def model(self) -> Optional[Model]:
+    def model(self) -> Model:
         """Represents the current model."""
         current_state = self.current_alias and self._models.get(self.current_alias)
-        return current_state.model if current_state else None
+        if current_state:
+            return current_state.model
+        raise ModelNotFoundError("Cannot obtain current model")
 
     @property
     def model_full_name(self) -> Optional[str]:
@@ -523,10 +525,12 @@ class OpsTest:
         return current_state.full_name if current_state else None
 
     @property
-    def model_name(self) -> Optional[str]:
+    def model_name(self) -> str:
         """Represents the current model name."""
         current_state = self.current_alias and self._models.get(self.current_alias)
-        return current_state.model_name if current_state else None
+        if current_state:
+            return current_state.model_name
+        raise ModelNotFoundError("Cannot obtain current model")
 
     @property
     def cloud_name(self) -> Optional[str]:

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -422,7 +422,8 @@ async def test_fixture_set_up_existing_model(
 ):
     setup_request.config.option.model = "this-model"
     ops_test = plugin.OpsTest(setup_request, tmp_path_factory)
-    assert ops_test.model is None
+    with pytest.raises(plugin.ModelNotFoundError):
+        _ = ops_test.model
 
     await ops_test._setup_model()
     mock_juju.model.connect.assert_called_with("this-controller:this-model")
@@ -462,7 +463,8 @@ async def test_fixture_set_up_automatic_model(
     model_name = "this-auto-generated-model-name"
     mock_default_model_name.return_value = model_name
     ops_test = plugin.OpsTest(setup_request, tmp_path_factory)
-    assert ops_test.model is None
+    with pytest.raises(plugin.ModelNotFoundError):
+        _ = ops_test.model
 
     await ops_test._setup_model()
     mock_juju.controller.add_model.assert_called_with(


### PR DESCRIPTION
Statically checking integration tests before attempting to run them can save some time.

#85 added a py.typed marker, but this results in a lot of the following:

```
tests/integration/test_resource_limits.py:38: error: Item "None" of "Optional[Any]" has no attribute "deploy"  [union-attr]
        await ops_test.model.deploy(
              ^
tests/integration/test_resource_limits.py:45: error: Item "None" of "Optional[Any]" has no attribute "wait_for_idle"  [union-attr]
        await ops_test.model.wait_for_idle(status="active", timeout=deploy_timeout)
              ^
tests/integration/test_resource_limits.py:60: error: Item "None" of "Optional[Any]" has no attribute "applications"  [union-attr]
        await ops_test.model.applications[app_name].set_config(custom_limits)
              ^
```

The changes proposed in this PR are problematic because they breaks backwards compatibility.
That being said, I assume that very few (if any) use cases exist relying on getting a None for the model, etc.