### PR TITLE
unit tests to passing with tox 4.x

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -1029,10 +1029,10 @@ class OpsTest:
                 resources[rsc_name].arch = "amd64"
         return resources
 
-    def arch_specific_resources(self, build_charm):
+    def arch_specific_resources(self, built_charm):
         return {
             name: rsc
-            for name, rsc in self.charm_file_resources(build_charm).items()
+            for name, rsc in self.charm_file_resources(built_charm).items()
             if rsc.arch
         }
 

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -210,7 +210,7 @@ async def test_plugin_build_resources(tmp_path_factory):
     assert resources and resources == expected_resources
 
 
-def test_plugin_get_resources(tmp_path_factory, resource_charm):
+async def test_plugin_get_resources(tmp_path_factory, resource_charm):
     ops_test = plugin.OpsTest(Mock(**{"module.__name__": "test"}), tmp_path_factory)
     resources = ops_test.arch_specific_resources(resource_charm)
     assert resources.keys() == {"resource-file-arm64", "resource-file"}

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands = pytest \
 [testenv:integration]
 passenv = HOME
 commands =
-    pytest --tb=native --show-capture=no --log-cli-level=INFO\
+    pytest --tb=native --show-capture=no --log-cli-level=INFO \
            -vs --ignore=tests/data --ignore=tests/unit \
            --model-config tests/data/model-config.yaml {posargs:tests/integration}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -27,16 +27,16 @@ deps =
     pytest-cov
     pytest-html
 commands = pytest \
+	     --asyncio-mode=auto \
           --cov=pytest_operator \
-	      --cov-report=term-missing \
-	      --cov-report=annotate:{toxinidir}/report/unit/coverage-annotated \
-	      --cov-report=html:{toxinidir}/report/unit/coverage-html \
-	      --cov-report=xml:{toxinidir}/report/unit/coverage-xml \
+	     --cov-report=term-missing \
+	     --cov-report=annotate:{toxinidir}/report/unit/coverage-annotated \
+	     --cov-report=html:{toxinidir}/report/unit/coverage-html \
+	     --cov-report=xml:{toxinidir}/report/unit/coverage-xml \
           --cov-config={toxinidir}/tox.ini \
-	      --html={toxinidir}/report/unit/tests/index.html \
-	      --junitxml={toxinidir}/report/unit/junit.xml\
-	      --asyncio-mode=auto \
-         --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore=tests/data {posargs:tests/unit}
+	     --html={toxinidir}/report/unit/tests/index.html \
+	     --junitxml={toxinidir}/report/unit/junit.xml \
+          --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore=tests/data {posargs:tests/unit}
 
 [testenv:integration]
 passenv = HOME

--- a/tox.ini
+++ b/tox.ini
@@ -27,15 +27,15 @@ deps =
     pytest-cov
     pytest-html
 commands = pytest \
-	     --asyncio-mode=auto \
+          --asyncio-mode=auto \
           --cov=pytest_operator \
-	     --cov-report=term-missing \
-	     --cov-report=annotate:{toxinidir}/report/unit/coverage-annotated \
-	     --cov-report=html:{toxinidir}/report/unit/coverage-html \
-	     --cov-report=xml:{toxinidir}/report/unit/coverage-xml \
+          --cov-report=term-missing \
+          --cov-report=annotate:{toxinidir}/report/unit/coverage-annotated \
+          --cov-report=html:{toxinidir}/report/unit/coverage-html \
+          --cov-report=xml:{toxinidir}/report/unit/coverage-xml \
           --cov-config={toxinidir}/tox.ini \
-	     --html={toxinidir}/report/unit/tests/index.html \
-	     --junitxml={toxinidir}/report/unit/junit.xml \
+          --html={toxinidir}/report/unit/tests/index.html \
+          --junitxml={toxinidir}/report/unit/junit.xml \
           --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore=tests/data {posargs:tests/unit}
 
 [testenv:integration]


### PR DESCRIPTION
* tox 4.x requires multi-line commands to have careful line-termination in alignment with spaces in a command
* fix argument name in `ops_test.arch_specific_resources`
* mark a unit test as `async`  since it depends on an async fixture