### PR TITLE
Update bundle related methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .tox
 *__pycache__
 *egg-info


### PR DESCRIPTION
## Description

This pull request aims to fix the issues that I identified in issue #98. Here is the summary of modifications that I made below:

* Modify `build_bundle` method to use `charmcraft pack` rather than `juju-bundle`. It now returns a Path object that points to where the built bundle zip archive is stored.
* Added the `build_bundles` method to build bundles asynchronously .
* Modified `deploy_bundle` to use `juju deploy ...` rather than `juju-bundle`.
* Updated the regex in `render_bundle` to also accept the _.tmpl_ file extension. I also enhanced the robustness of the expression. The original regex would match inputs such as `xyamlij2`, `Byaml`, etc since "." means any character. I modified it so that the regex would only accept the "." character.

## Related issues

* Closes #98 

## Miscellaneous

I updated the `.gitignore` file to ignore the `.idea` directory. I made this modification since I use PyCharm. I also added a hashbang and copyright information to the top of `plugin.py`.