### PR TITLE
break requirement on `TOX_ENV_DIR` to create temporary directories

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,13 +18,34 @@ jobs:
     needs:
       - call-inclusive-naming-check
 
-  integration-test:
-    name: Integration test with LXD
+  integration-test-3-0:
+    name: Integration test with juju
     runs-on: ubuntu-22.04
     timeout-minutes: 40
     strategy:
       matrix:
         juju: ['2.9', '3.0']
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Setup operator test environment
+      uses: charmed-kubernetes/actions-operator@main
+      with:
+        juju-channel: ${{ matrix.juju }}/stable
+    - name: Run integration tests
+      run: tox -e integration-3.0
+
+  integration-test:
+    name: Integration test with juju
+    runs-on: ubuntu-22.04
+    timeout-minutes: 40
+    strategy:
+      matrix:
+        juju: ['3.1']
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,9 @@ jobs:
     name: Integration test with LXD
     runs-on: ubuntu-22.04
     timeout-minutes: 40
+    strategy:
+      matrix:
+        juju: ['2.9', '3.0']
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -31,5 +34,7 @@ jobs:
         python-version: '3.10'
     - name: Setup operator test environment
       uses: charmed-kubernetes/actions-operator@main
+      with:
+        juju-channel: ${{ matrix.juju }}/stable
     - name: Run integration tests
       run: tox -e integration

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -57,11 +57,22 @@ This is the primary interface for the plugin, and provides an instance of the [`
 class](#OpsTest).
 
 
-### `tmp_path_factory`
+### `basetemp`
 
-This overrides the default `tmp_path_factory` fixture from pytest to relocate any
-temporary directories to under `$TOX_ENV_DIR/tmp/pytest`. This is done because strictly
-confined snaps, like `charmcraft`, can't access the global `/tmp`.
+Some snap tools are dropping their `classic` snap support, and will
+lose the ability to write anywhere on the filesystem. Tests should
+be run to confirm they're located within the user's `HOME` directory
+so strictly confined snaps can write to temporary directories. 
+
+Temp Directories can be moved with the following options:
+
+If `basetemp` is provided as pytest configuration
+   * pytest will create a directory here for temporary files
+If `basetemp` is not provided as pytest configuration
+   * the plugin will look to `TOX_ENV_DIR` environment variable
+   * if that env var is set, `${tox_env_dir}/tmp/pytest` will be used
+If `basetemp` and `TOX_ENV_DIR` are both unset
+   * pytest is responsible for creating a temporary directory
 
 
 ### `event_loop`

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -141,9 +141,9 @@ def tmp_path_factory(request):
     strictly confined snaps (e.g., juju, charmcraft) can access them.
     if   TMPDIR       is in os.environ, use this as the basetemp
     elif TOX_ENV_DIR  is in os.environ, create a tmp/pytest/ directly beneath it
-    else use whatever pytest will naturally provide (may not handle strict confined snaps)
+    else default TempPathFactory (may not handle strict confined snaps)
     """
-   
+
     given_basetemp, basetemp = None, None
     tmpdir, toxdir = os.environ.get("TMPDIR"), os.environ.get("TOX_ENV_DIR")
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,1 +1,0 @@
-pytest_plugins = ["pytester"]

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 ENV = {_: os.environ.get(_) for _ in ["HOME", "TOX_ENV_DIR"]}
 
 
+@patch.object(plugin, "check_deps", Mock())
 def test_tmp_path_with_tox(pytester):
     pytester.makepyfile(
         f"""
@@ -33,9 +34,10 @@ def test_tmp_path_with_tox(pytester):
     result.assert_outcomes(passed=1)
 
 
+@patch.object(plugin, "check_deps", Mock())
 def test_tmp_path_without_tox(request, pytester):
     pytester.makepyfile(
-        """
+        f"""
         import os
         from pathlib import Path
 

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -15,12 +15,13 @@ log = logging.getLogger(__name__)
 
 ENV = {_: os.environ.get(_) for _ in ["HOME", "TOX_ENV_DIR"]}
 
+
 def test_tmp_path_with_tox(pytester):
     pytester.makepyfile(
         f"""
         import os
         from pathlib import Path
-        
+
         os.environ.update(**{ENV})
         async def test_with_tox(ops_test):
             expected_base = Path("{ENV["TOX_ENV_DIR"]}") / "tmp" / "pytest"
@@ -31,12 +32,13 @@ def test_tmp_path_with_tox(pytester):
     result = pytester.runpytest()
     result.assert_outcomes(passed=1)
 
+
 def test_tmp_path_without_tox(request, pytester):
     pytester.makepyfile(
-        f"""
+        """
         import os
         from pathlib import Path
-        
+
         os.environ.update(**{ENV})
         async def test_without_tox(request, ops_test):
             unexpected_base = Path("{ENV["TOX_ENV_DIR"]}") / "tmp" / "pytest"
@@ -48,7 +50,7 @@ def test_tmp_path_without_tox(request, pytester):
             assert expected_base == Path(common)
         """
     )
-    result = pytester.runpytest(f"--basetemp=/tmp/pytest")
+    result = pytester.runpytest("--basetemp=/tmp/pytest")
     result.assert_outcomes(passed=1)
 
 

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -17,6 +17,8 @@ ENV = {_: os.environ.get(_) for _ in ["HOME", "TOX_ENV_DIR"]}
 
 
 @patch.object(plugin, "check_deps", Mock())
+@patch.object(plugin.OpsTest, "_setup_model", AsyncMock())
+@patch.object(plugin.OpsTest, "_cleanup_models", AsyncMock())
 def test_tmp_path_with_tox(pytester):
     pytester.makepyfile(
         f"""
@@ -35,6 +37,8 @@ def test_tmp_path_with_tox(pytester):
 
 
 @patch.object(plugin, "check_deps", Mock())
+@patch.object(plugin.OpsTest, "_setup_model", AsyncMock())
+@patch.object(plugin.OpsTest, "_cleanup_models", AsyncMock())
 def test_tmp_path_without_tox(request, pytester):
     pytester.makepyfile(
         f"""

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from unittest.mock import Mock, AsyncMock, ANY, patch, call, MagicMock, PropertyMock
 from urllib.error import HTTPError
 from pathlib import Path
@@ -11,6 +12,44 @@ import pytest
 from pytest_operator import plugin
 
 log = logging.getLogger(__name__)
+
+ENV = {_: os.environ.get(_) for _ in ["HOME", "TOX_ENV_DIR"]}
+
+def test_tmp_path_with_tox(pytester):
+    pytester.makepyfile(
+        f"""
+        import os
+        from pathlib import Path
+        
+        os.environ.update(**{ENV})
+        async def test_with_tox(ops_test):
+            expected_base = Path("{ENV["TOX_ENV_DIR"]}") / "tmp" / "pytest"
+            common = os.path.commonpath([ops_test.tmp_path, expected_base])
+            assert expected_base == Path(common)
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+def test_tmp_path_without_tox(request, pytester):
+    pytester.makepyfile(
+        f"""
+        import os
+        from pathlib import Path
+        
+        os.environ.update(**{ENV})
+        async def test_without_tox(request, ops_test):
+            unexpected_base = Path("{ENV["TOX_ENV_DIR"]}") / "tmp" / "pytest"
+            common = os.path.commonpath([ops_test.tmp_path, unexpected_base])
+            assert unexpected_base != Path(common)
+
+            expected_base = Path("/tmp/pytest")
+            common = os.path.commonpath([ops_test.tmp_path, expected_base])
+            assert expected_base == Path(common)
+        """
+    )
+    result = pytester.runpytest(f"--basetemp=/tmp/pytest")
+    result.assert_outcomes(passed=1)
 
 
 async def test_destructive_mode(monkeypatch, tmp_path_factory):
@@ -283,9 +322,8 @@ async def test_crash_dump_mode(monkeypatch, tmp_path_factory):
     """Test running juju-crashdump in OpsTest.cleanup."""
     patch = monkeypatch.setattr
     patch(plugin.OpsTest, "run", mock_run := AsyncMock(return_value=(0, "", "")))
-    ops_test = plugin.OpsTest(
-        mock_request := Mock(**{"module.__name__": "test"}), tmp_path_factory
-    )
+    mock_request = Mock(**{"module.__name__": "test"})
+    ops_test = plugin.OpsTest(mock_request, tmp_path_factory)
     ops_test.crash_dump = True
     model = MagicMock()
     model.machines.values.return_value = []

--- a/tox.ini
+++ b/tox.ini
@@ -38,15 +38,29 @@ commands = pytest \
           --junitxml={toxinidir}/report/unit/junit.xml \
           --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore=tests/data {posargs:tests/unit}
 
-[testenv:integration]
-passenv = HOME
+
+[integration]
 commands =
-    pytest --tb=native --show-capture=no --log-cli-level=INFO \
-           -vs --ignore=tests/data --ignore=tests/unit \
-           --model-config tests/data/model-config.yaml {posargs:tests/integration}
+    pytest --tb=native \
+           --asyncio-mode=auto \
+           --show-capture=no \
+           --log-cli-level=INFO \
+           --ignore=tests/data --ignore=tests/unit \
+           --model-config tests/data/model-config.yaml \
+           -vs {posargs:tests/integration}
+deps = -e {toxinidir}
+
+[testenv:integration]
+# run integration tests if bootstrapped with a juju 3.1 controller
+deps = {[integration]deps}
+commands = {[integration]commands}
+
+[testenv:integration-3.0]
+# run integration tests if bootstrapped with a juju 2.9 or juju 3.0 controller
 deps =
     juju < 3.1
-     -e {toxinidir}
+    {[integration]deps}
+commands = {[integration]commands}
 
 [testenv:publish]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands =
            --log-cli-level=INFO \
            --ignore=tests/data --ignore=tests/unit \
            --model-config tests/data/model-config.yaml \
-           -vs {posargs:tests/integration}
+           -vs {posargs} tests/integration
 deps = -e {toxinidir}
 
 [testenv:integration]

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,9 @@ commands = pytest \
           --cov-config={toxinidir}/tox.ini \
           --html={toxinidir}/report/unit/tests/index.html \
           --junitxml={toxinidir}/report/unit/junit.xml \
-          --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore=tests/data {posargs:tests/unit}
+          -p pytester -p pytest_operator \
+          --ignore=tests/data --ignore=tests/integration \
+          --tb=native --show-capture=no --log-cli-level=INFO -vs {posargs:tests/unit}
 
 
 [integration]

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ commands =
            -vs --ignore=tests/data --ignore=tests/unit \
            --model-config tests/data/model-config.yaml {posargs:tests/integration}
 deps =
-    juju
+    juju < 3.1
      -e {toxinidir}
 
 [testenv:publish]


### PR DESCRIPTION
Addressing https://github.com/charmed-kubernetes/pytest-operator/issues/92 and providing a way to not necessarily use the `TOX_ENV_DIR` to host temporary files. 

There are circumstances when the `juju` snap needs to write files, but cannot use the `TOX_ENV_DIR` path because it's not under the user's `$HOME` directory. 

This change will honor `TMPDIR` first before `TOX_ENV_DIR`