### PR TITLE
Use current alias as default alias for `forget_model`

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -23,7 +23,7 @@ Keep any automatically created models.
 
 Path to a yaml file which will be applied to the model on creation.
 
- * ignored if `--model` supplied 
+ * ignored if `--model` supplied
  * if the specified file doesn't exist, an error will be raised.
 
 ### `--model-alias`
@@ -36,7 +36,7 @@ name of the model as known by juju.  For that see `--model`.
 ### `--no-deploy`
 
 Flag that guarantees skipping the function marked with `skip_if_deployed`. The skip will
-only work if the `--model` parameter is also provided. 
+only work if the `--model` parameter is also provided.
 
 ### `--no-crash-dump`
 
@@ -62,7 +62,7 @@ class](#OpsTest).
 Some snap tools are dropping their `classic` snap support, and will
 lose the ability to write anywhere on the filesystem. Tests should
 be run to confirm they're located within the user's `HOME` directory
-so strictly confined snaps can write to temporary directories. 
+so strictly confined snaps can write to temporary directories.
 
 Temp Directories can be moved with the following options:
 
@@ -142,7 +142,7 @@ The name of the controller being used.
 
 #### `model_name`
 
-The name of the juju model referenced by the current aliased model. 
+The name of the juju model referenced by the current aliased model.
 If the alias is set as the first model, that name will reflect its automatically generated
 name or the name provided by the `--model` command-line parameter.
 
@@ -258,7 +258,7 @@ provide as many bundles as necessary from any of the follow types:
   * `OpsTest.Bundle`
     * bundles can be downloaded from charmhub using a Bundle object.
       The bundle is downloaded, unpacked, and its `bundle.yaml` file is used as the content.
-      
+
       See [ops_test.Bundle](#Bundle)
 
 
@@ -314,7 +314,7 @@ is cleaned up.
 
 #### `async def track_model(self, alias: str, model_name: Optional[str] = None, cloud_name: Optional[str] = None, use_existing: Optional[bool] = None, keep: Optional[bool] = None, **kwargs,) -> Model`
 
-Indicate to `ops_test` to track a new model which is automatically created in juju or an existing juju model referenced by model_name. 
+Indicate to `ops_test` to track a new model which is automatically created in juju or an existing juju model referenced by model_name.
 This allows `ops_test` to track multiple models on various clouds by a unique alias name.
 
 ##### Key parameters:
@@ -325,7 +325,7 @@ This allows `ops_test` to track multiple models on various clouds by a unique al
   * `None` (default): `ops_test` will re-use an existing model-name if provided, otherwise False
   * `False`: `ops_test` creates a new model
   * `True`: `ops_test` won't create a new model, but will connect to an existing model by `model_name`
-* `keep`: 
+* `keep`:
   * `None` (default): inherit boolean value of `use_existing`
   * `False`: `ops_test` will destroy at the end of testing
   * `True`: `ops_test` won't destroy at the end of testing
@@ -337,7 +337,7 @@ This allows `ops_test` to track multiple models on various clouds by a unique al
 await ops_test.track_model("alias")
 
 # make a new model with any juju name but don't destroy it when the tests are over
-await ops_test.track_model("alias", keep=True)  
+await ops_test.track_model("alias", keep=True)
 
 # Invalid, can't reuse an existing model when the model_name isn't provided
 await ops_test.track_model("alias", use_existing=True)
@@ -366,17 +366,17 @@ await ops_test.track_model("alias", model_name="bob")
 await ops_test.track_model("alias", model_name="bob", keep=True)
 ```
 
-#### `async def forget_model(self, alias: str, timeout: Optional[Union[float, int]] = None)`
+#### `async def forget_model(self, alias: Optional[str] = None, timeout: Optional[Union[float, int]] = None)`
 
 Indicate to `ops_test` to forget an existing model and `destroy` that model except under the following circumstances.
 
 * If `--keep-models` was passed as a tox argument, no models will be destroyed.
 * If `--model=<specific model>` was passed as a tox argument, this specific model will not be destroyed.
 
-A Timeout Exception will be raised if a `timeout` value is specified and the model isn't destroyed 
+A Timeout Exception will be raised if a `timeout` value is specified and the model isn't destroyed
 within that number of seconds.
 
-it's possible to determine if the model is a candidate for destroying using 
+it's possible to determine if the model is a candidate for destroying using
 ```python
     assert ops_test._init_keep_model is False # this flag is set when the keep-models argument is passed to pytest
     assert ops_test.models["main"].keep is False  # by default, we forget and destroy models
@@ -387,7 +387,7 @@ it's possible to determine if the model is a candidate for destroying using
 #### `def model_context(self, alias: str) -> Generator[Model, None, None]:`
 
 The only way to switch between tracked models is by using this method to change
-the context of the model to which the tests refer.   
+the context of the model to which the tests refer.
 
 For example, assume there are two models being tracked by ops_test: "main" and "secondary"
 The following test would `PASS` due to the nature of `model_context`'s function.

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -782,7 +782,7 @@ class OpsTest:
 
     async def forget_model(
         self,
-        alias: str,
+        alias: Optional[str] = None,
         timeout: Optional[Timeout] = None,
         allow_failure: bool = True,
     ):
@@ -792,7 +792,7 @@ class OpsTest:
         If the model is not marked as kept, ops_test will destroy the model.
         If timeout is None don't wait on the model to be completely destroyed
 
-        @param                   str alias: alias of the model
+        @param                   str alias: alias of the model (default: current alias)
         @param Optional[float,int] timeout: how long to wait for it to be removed,
                                             if None, don't block waiting for success
         @param          bool allow_failure: if False, failures raise an exception
@@ -800,6 +800,9 @@ class OpsTest:
         if not self._controller:
             log.error("No access to controller, skipping...")
             return
+
+        if not alias:
+            alias = self.current_alias
 
         if alias not in self.models:
             raise ModelNotFoundError(f"{alias} not found")


### PR DESCRIPTION
It is natural to just `await ops_test.forget_model()`, but that would error:
```
TypeError: OpsTest.forget_model() missing 1 required positional argument: ...
```

Use `self.current_alias` as default, instead, so passing it wouldn't be necessary.

Note: PyCharm made some whitespace fixes automatically :)