### PR TITLE
Add verbosity flag to build_charm

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -156,7 +156,7 @@ Dataclass which represents a juju bundle.
 
 ### Methods
 
-#### `async def build_charm(self, charm_path, bases_index = None)`
+#### `async def build_charm(self, charm_path, bases_index = None, verbosity = None)`
 
 Builds a charm.
 

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -23,6 +23,7 @@ from typing import (
     Generator,
     Iterable,
     List,
+    Literal,
     MutableMapping,
     Mapping,
     Optional,
@@ -897,7 +898,14 @@ class OpsTest:
         self.aborted = True
         pytest.fail(*args, **kwargs)
 
-    async def build_charm(self, charm_path, bases_index: int = None) -> Path:
+    async def build_charm(
+        self,
+        charm_path,
+        bases_index: int = None,
+        verbosity: Optional[
+            Literal["quiet", "brief", "verbose", "debug", "trace"]
+        ] = None,
+    ) -> Path:
         """Builds a single charm.
 
         This can handle charms using the older charms.reactive framework as
@@ -923,6 +931,8 @@ class OpsTest:
             cmd = ["charmcraft", "pack"]
             if bases_index is not None:
                 cmd.append(f"--bases-index={bases_index}")
+            if verbosity:
+                cmd.append(f"--verbosity={verbosity}")
             if self.destructive_mode:
                 # host builder never requires lxd group
                 cmd.append("--destructive-mode")


### PR DESCRIPTION
When [charms fail to build in CI](https://github.com/canonical/traefik-k8s-operator/actions/runs/4457784790/jobs/7829062070#step:5:891), all we see is 
```
 RuntimeError: Failed to build charm .:
Packing the charm.
Launching environment to pack for base name='ubuntu' channel='20.04' architectures=['amd64'] (may take a while the first time but it's reusable)
Packing the charm
Packing the charm.
Building charm in '/root'
Running step PULL for part 'charm'
Running step OVERLAY for part 'charm'
Running step BUILD for part 'charm'
Parts processing error: Failed to run the build script for part 'charm'.
Failed to build charm for bases index '0'.
Full execution log: '/home/runner/.local/state/charmcraft/log/charmcraft-20230319-020431.474806.log'
```

It could be handy to temporarily (or permanently) enable verbosity so debugging is more immediate.