### PR TITLE
feat: expand on options for calling juju crashdump

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -40,8 +40,17 @@ only work if the `--model` parameter is also provided.
 
 ### `--no-crash-dump`
 
-This flag disables the automatic execution of `juju-crashdump`, which runs by default
-(if a command is available) after failed tests.
+(Deprecated - use '--crash-dump=never' instead.  Overrides anything specified in 
+'--crash-dump') This flag disables the automatic execution of `juju-crashdump`, 
+which runs by default (if a command is available) after failed tests.
+
+### `--crash-dump`
+
+Sets whether to output a juju-crashdump after tests.  Options are:
+* always: dumps after all tests
+* on-failure: dumps after failed tests
+* legacy: (DEFAULT) dumps after a failed test if '--keep-models' is False
+* never: never dumps
 
 ### `--crash-dump-output`
 

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -89,8 +89,8 @@ def pytest_addoption(parser: Parser):
     parser.addoption(
         "--no-crash-dump",
         action="store_true",
-        help="(Deprecated - use --crash-dump=never instead.  Overrides anything"
-        " specified in --crash-dump)\n"
+        help="(Deprecated - use '--crash-dump=never' instead.  Overrides anything"
+        " specified in '--crash-dump')\n"
         "Disable automatic runs of juju-crashdump after failed tests, "
         "juju-crashdump runs by default.",
     )
@@ -101,7 +101,7 @@ def pytest_addoption(parser: Parser):
         help="Sets whether to output a juju-crashdump after tests.  Options are:\n"
         "* always: dumps after all tests\n"
         "* on-failure: dumps after failed tests\n"
-        "* legacy: (DEFAULT) dumps after a failed test if --keep-models is False\n"
+        "* legacy: (DEFAULT) dumps after a failed test if '--keep-models' is False\n"
         "* never: never dumps",
     )
     parser.addoption(

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -89,20 +89,20 @@ def pytest_addoption(parser: Parser):
     parser.addoption(
         "--no-crash-dump",
         action="store_true",
-        help="(Deprecated - use --crash-dump=never instead.  Overrides anything specified in"
-             "--crash-dump)\n"
-            "Disable automatic runs of juju-crashdump after failed tests, "
-            "juju-crashdump runs by default.",
+        help="(Deprecated - use --crash-dump=never instead.  Overrides anything"
+             " specified in --crash-dump)\n"
+        "Disable automatic runs of juju-crashdump after failed tests, "
+        "juju-crashdump runs by default.",
     )
     parser.addoption(
         "--crash-dump",
         action="store",
         default="legacy",
         help="Sets whether to output a juju-crashdump after tests.  Options are:\n"
-            "* always: dumps after all tests\n"
-            "* on-failure: dumps after failed tests\n"
-            "* legacy: (DEFAULT) dumps after a failed test if --keep-models is False\n"
-            "* never: never dumps"
+        "* always: dumps after all tests\n"
+        "* on-failure: dumps after failed tests\n"
+        "* legacy: (DEFAULT) dumps after a failed test if --keep-models is False\n"
+        "* never: never dumps",
     )
     parser.addoption(
         "--crash-dump-output",
@@ -242,21 +242,21 @@ def handle_file_delete_error(function, path, execinfo):
 def validate_crash_dump(crash_dump: str, no_crash_dump: bool):
     """Validates the crash-dump inputs, raising if they are not accepted values."""
     if no_crash_dump:
-        log.warning("Got flag --no-crash-dump.  Ignoring value of flag --crash-dump and "
-                    "setting --crash-dump=never")
+        log.warning(
+            "Got flag --no-crash-dump.  Ignoring value of flag --crash-dump and "
+            "setting --crash-dump=never"
+        )
         crash_dump = "never"
 
-    accepted_crash_dump = [
-        "always",
-        "legacy",
-        "on-failure",
-        "never"
-    ]
+    accepted_crash_dump = ["always", "legacy", "on-failure", "never"]
     if crash_dump not in accepted_crash_dump:
-        raise ValueError(f"Got invalid --crash-dump={crash_dump}, must be one of"
-                         f" {accepted_crash_dump}")
+        raise ValueError(
+            f"Got invalid --crash-dump={crash_dump}, must be one of"
+            f" {accepted_crash_dump}"
+        )
 
     return crash_dump
+
 
 class FileResource:
     """Represents a File based Resource."""
@@ -1420,15 +1420,12 @@ class OpsTest:
 
     def is_crash_dump_enabled(self) -> bool:
         """Returns whether Juju crash dump is enabled given the current settings."""
-        if self.crash_dump == 'always':
+        if self.crash_dump == "always":
+            return True
+        elif self.crash_dump == "on-failure" and self.request.session.testsfailed > 0:
             return True
         elif (
-            self.crash_dump == 'on-failure'
-            and self.request.session.testsfailed > 0
-        ):
-            return True
-        elif (
-            self.crash_dump == 'legacy'
+            self.crash_dump == "legacy"
             and self.request.session.testsfailed > 0
             and self.keep_model is False
         ):

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -90,7 +90,7 @@ def pytest_addoption(parser: Parser):
         "--no-crash-dump",
         action="store_true",
         help="(Deprecated - use --crash-dump=never instead.  Overrides anything"
-             " specified in --crash-dump)\n"
+        " specified in --crash-dump)\n"
         "Disable automatic runs of juju-crashdump after failed tests, "
         "juju-crashdump runs by default.",
     )

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -89,8 +89,20 @@ def pytest_addoption(parser: Parser):
     parser.addoption(
         "--no-crash-dump",
         action="store_true",
-        help="Disabled automatic runs of juju-crashdump after failed tests, "
-        "juju-crashdump runs by default.",
+        help="(Deprecated - use --crash-dump=never instead.  Overrides anything specified in"
+             "--crash-dump)\n"
+            "Disable automatic runs of juju-crashdump after failed tests, "
+            "juju-crashdump runs by default.",
+    )
+    parser.addoption(
+        "--crash-dump",
+        action="store",
+        default="legacy",
+        help="Sets whether to output a juju-crashdump after tests.  Options are:\n"
+            "* always: dumps after all tests\n"
+            "* on-failure: dumps after failed tests\n"
+            "* legacy: (DEFAULT) dumps after a failed test if --keep-models is False\n"
+            "* never: never dumps"
     )
     parser.addoption(
         "--crash-dump-output",
@@ -226,6 +238,25 @@ async def ops_test(request, tmp_path_factory):
 def handle_file_delete_error(function, path, execinfo):
     log.warning(f"Failed to delete '{path}' due to {execinfo[1]}")
 
+
+def validate_crash_dump(crash_dump: str, no_crash_dump: bool):
+    """Validates the crash-dump inputs, raising if they are not accepted values."""
+    if no_crash_dump:
+        log.warning("Got flag --no-crash-dump.  Ignoring value of flag --crash-dump and "
+                    "setting --crash-dump=never")
+        crash_dump = "never"
+
+    accepted_crash_dump = [
+        "always",
+        "legacy",
+        "on-failure",
+        "never"
+    ]
+    if crash_dump not in accepted_crash_dump:
+        raise ValueError(f"Got invalid --crash-dump={crash_dump}, must be one of"
+                         f" {accepted_crash_dump}")
+
+    return crash_dump
 
 class FileResource:
     """Represents a File based Resource."""
@@ -430,7 +461,10 @@ class OpsTest:
         self._init_model_config = request.config.option.model_config
 
         # Flag for enabling the juju-crashdump
-        self.crash_dump = not request.config.option.no_crash_dump
+        self.crash_dump = validate_crash_dump(
+            crash_dump=request.config.option.crash_dump,
+            no_crash_dump=request.config.option.no_crash_dump,
+        )
         self.crash_dump_output = request.config.option.crash_dump_output
 
         # These will be set by _setup_model
@@ -812,13 +846,7 @@ class OpsTest:
             await self.log_model()
             model_name = model.info.name
 
-            # NOTE (rgildein): Create juju-crashdump only if any tests failed,
-            # `juju-crashdump` flag is enabled and OpsTest.keep_model == False
-            if (
-                self.request.session.testsfailed > 0
-                and self.crash_dump
-                and self.keep_model is False
-            ):
+            if self.is_crash_dump_enabled():
                 await self.create_crash_dump()
 
             if not self.keep_model:
@@ -1389,3 +1417,21 @@ class OpsTest:
         await model.set_config({update_interval_key: fast_interval})
         yield
         await model.set_config({update_interval_key: interval_after})
+
+    def is_crash_dump_enabled(self) -> bool:
+        """Returns whether Juju crash dump is enabled given the current settings."""
+        if self.crash_dump == 'always':
+            return True
+        elif (
+            self.crash_dump == 'on-failure'
+            and self.request.session.testsfailed > 0
+        ):
+            return True
+        elif (
+            self.crash_dump == 'legacy'
+            and self.request.session.testsfailed > 0
+            and self.keep_model is False
+        ):
+            return True
+        else:
+            return False

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -325,19 +325,49 @@ async def test_async_render_bundles(tmp_path_factory):
         bundles = await ops_test.async_render_bundles(download_bundle, num=1)
     assert bundles[0].read_text() == "a: 1"
 
-
-async def test_crash_dump_mode(monkeypatch, tmp_path_factory):
+@pytest.mark.parametrize(
+    "crash_dump, no_crash_dump, n_testsfailed, keep_models, expected_crashdump",
+    [
+        # crash_dump == always && no_crash_dump == False -> always dump
+        ("always", False, 0, True, True),
+        ("always", False, 0, False, True),
+        ("always", False, 1, True, True),
+        ("always", False, 1, False, True),
+        # crash_dump == always && no_crash_dump == True -> never dump
+        ("always", True, 0, True, False),
+        ("always", True, 0, False, False),
+        ("always", True, 1, True, False),
+        ("always", True, 1, False, False),
+        # crash_dump == on-failure && no_crash_dump == False -> dump on failures
+        ("on-failure", False, 0, True, False),
+        ("on-failure", False, 0, False, False),
+        ("on-failure", False, 1, True, True),
+        ("on-failure", False, 1, False, True),
+        # crash_dump == legacy && no_crash_dump == False -> dump if failure and keep_model==False
+        ("legacy", False, 0, True, False),
+        ("legacy", False, 0, False, False),
+        ("legacy", False, 1, True, False),
+        ("legacy", False, 1, False, True),
+        # crash_dump == never -> never dump
+        ("never", False, 0, True, False),
+        ("never", False, 0, False, False),
+        ("never", False, 1, True, False),
+        ("never", False, 1, False, False),
+    ]
+)
+async def test_crash_dump_mode(crash_dump, no_crash_dump, n_testsfailed, keep_models, expected_crashdump, monkeypatch, tmp_path_factory):
     """Test running juju-crashdump in OpsTest.cleanup."""
     patch = monkeypatch.setattr
     patch(plugin.OpsTest, "run", mock_run := AsyncMock(return_value=(0, "", "")))
     mock_request = Mock(**{"module.__name__": "test"})
+    mock_request.config.option.crash_dump = crash_dump
+    mock_request.config.option.no_crash_dump = no_crash_dump
+    mock_request.config.option.keep_models = keep_models
     ops_test = plugin.OpsTest(mock_request, tmp_path_factory)
-    ops_test.crash_dump = True
     model = MagicMock()
     model.machines.values.return_value = []
     model.disconnect = AsyncMock()
     model.block_until = AsyncMock()
-    ops_test._init_keep_model = None
     ops_test._current_alias = "main"
     ops_test._models = {
         ops_test.current_alias: plugin.ModelState(
@@ -348,36 +378,36 @@ async def test_crash_dump_mode(monkeypatch, tmp_path_factory):
     ops_test.log_model = AsyncMock()
     ops_test._controller = AsyncMock()
 
-    # 0 tests failed
-    mock_request.session.testsfailed = 0
+    mock_request.session.testsfailed = n_testsfailed
 
     await ops_test._cleanup_model()
 
-    mock_run.assert_not_called()
-    mock_run.reset_mock()
-
-    # 1 tests failed
-    ops_test._current_alias = "main"
-    ops_test._models = {
-        ops_test.current_alias: plugin.ModelState(
-            model, False, "test", "local", "model"
+    if expected_crashdump:
+        mock_run.assert_called_once_with(
+            "juju-crashdump",
+            "-s",
+            "-m",
+            "test:model",
+            "-a",
+            "debug-layer",
+            "-a",
+            "config",
         )
-    }
-    mock_request.session.testsfailed = 1
+    else:
+        mock_run.assert_not_called()
 
-    await ops_test._cleanup_model()
 
-    mock_run.assert_called_once_with(
-        "juju-crashdump",
-        "-s",
-        "-m",
-        "test:model",
-        "-a",
-        "debug-layer",
-        "-a",
-        "config",
-    )
-    mock_run.reset_mock()
+def test_crash_dump_mode_invalid_input(monkeypatch, tmp_path_factory):
+    """Test running juju-crashdump in OpsTest.cleanup."""
+    patch = monkeypatch.setattr
+    patch(plugin.OpsTest, "run", mock_run := AsyncMock(return_value=(0, "", "")))
+    mock_request = Mock(**{"module.__name__": "test"})
+    mock_request.config.option.crash_dump = "not-a-real-option"
+    mock_request.config.option.no_crash_dump = False
+    mock_request.config.option.keep_models = False
+
+    with pytest.raises(ValueError):
+        plugin.OpsTest(mock_request, tmp_path_factory)
 
 
 async def test_create_crash_dump(monkeypatch, tmp_path_factory):

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -325,6 +325,7 @@ async def test_async_render_bundles(tmp_path_factory):
         bundles = await ops_test.async_render_bundles(download_bundle, num=1)
     assert bundles[0].read_text() == "a: 1"
 
+
 @pytest.mark.parametrize(
     "crash_dump, no_crash_dump, n_testsfailed, keep_models, expected_crashdump",
     [
@@ -343,7 +344,8 @@ async def test_async_render_bundles(tmp_path_factory):
         ("on-failure", False, 0, False, False),
         ("on-failure", False, 1, True, True),
         ("on-failure", False, 1, False, True),
-        # crash_dump == legacy && no_crash_dump == False -> dump if failure and keep_model==False
+        # crash_dump == legacy && no_crash_dump == False ->
+        #   dump if failure and keep_model==False
         ("legacy", False, 0, True, False),
         ("legacy", False, 0, False, False),
         ("legacy", False, 1, True, False),
@@ -353,9 +355,17 @@ async def test_async_render_bundles(tmp_path_factory):
         ("never", False, 0, False, False),
         ("never", False, 1, True, False),
         ("never", False, 1, False, False),
-    ]
+    ],
 )
-async def test_crash_dump_mode(crash_dump, no_crash_dump, n_testsfailed, keep_models, expected_crashdump, monkeypatch, tmp_path_factory):
+async def test_crash_dump_mode(
+    crash_dump,
+    no_crash_dump,
+    n_testsfailed,
+    keep_models,
+    expected_crashdump,
+    monkeypatch,
+    tmp_path_factory,
+):
     """Test running juju-crashdump in OpsTest.cleanup."""
     patch = monkeypatch.setattr
     patch(plugin.OpsTest, "run", mock_run := AsyncMock(return_value=(0, "", "")))
@@ -400,7 +410,9 @@ async def test_crash_dump_mode(crash_dump, no_crash_dump, n_testsfailed, keep_mo
 def test_crash_dump_mode_invalid_input(monkeypatch, tmp_path_factory):
     """Test running juju-crashdump in OpsTest.cleanup."""
     patch = monkeypatch.setattr
-    patch(plugin.OpsTest, "run", mock_run := AsyncMock(return_value=(0, "", "")))
+    patch(plugin.OpsTest, "run", AsyncMock(
+        return_value=(0, "", ""))
+    )
     mock_request = Mock(**{"module.__name__": "test"})
     mock_request.config.option.crash_dump = "not-a-real-option"
     mock_request.config.option.no_crash_dump = False

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -410,9 +410,7 @@ async def test_crash_dump_mode(
 def test_crash_dump_mode_invalid_input(monkeypatch, tmp_path_factory):
     """Test running juju-crashdump in OpsTest.cleanup."""
     patch = monkeypatch.setattr
-    patch(plugin.OpsTest, "run", AsyncMock(
-        return_value=(0, "", ""))
-    )
+    patch(plugin.OpsTest, "run", AsyncMock(return_value=(0, "", "")))
     mock_request = Mock(**{"module.__name__": "test"})
     mock_request.config.option.crash_dump = "not-a-real-option"
     mock_request.config.option.no_crash_dump = False


### PR DESCRIPTION
This PR adds new controls over whether pytest-operator outputs a juju crashdump.  Previously, the crashdump was output only if tests failed and `--keep-models==False`.  This commit adds additional modes:

* always: dumps after all tests
* on-failure: dumps after failed tests
* legacy: (DEFAULT) dumps after a failed test if --keep-models is False
* never: never dumps