### PR TITLE
When model switch is used, reuse or create and keep that model

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        juju: ['2.9', '3.0']
+        juju: ['2.9']
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
         juju-channel: ${{ matrix.juju }}/stable
 
     - name: Run integration tests
-      run: tox -e integration-3.0
+      run: tox -e integration-2.9
 
     - name: Collect Charmcraft Logs
       if: ${{ failure() }}
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        juju: ['3.1']
+        juju: ['3.1', '3.2']
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -12,8 +12,17 @@ Juju controller to use. If not provided, it will use the current controller.
 
 ### `--model`
 
-Juju model to use. If not provided, a new model will be created for each test module.
-All tests within a module will share the same model.
+Juju model to use. 
+
+If not provided, a new model will be created for each test module file.
+- All tests within a module will share the same model.
+- The model will be destroyed at the end of the test module's scope
+
+If provided, `ops_test` will attempt to use an existing model by this name
+on the specified controller.  
+* If that model does exist, it will be reused
+* If that model doesn't exist, a new model by this name will be created
+* The model will not be destroyed at the end of the test module's scope
 
 ### `--keep-models`
 

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -706,21 +706,14 @@ class OpsTest:
         if not self._controller:
             self._controller = Controller()
             await self._controller.connect(self.controller_name)
-        if not self._init_model_name:
-            # no --model flag specified, automatically generate a model
-            config = self.read_model_config(self._init_model_config)
-            model_state = await self._add_model(
-                self._init_cloud_name,
-                self.default_model_name,
-                config=config,
-            )
-        else:
-            # --model flag specified, reuse existing model and set keep flag
-            model_state = await self._connect_to_model(
-                self.controller_name, self._init_model_name
-            )
 
-        self._models[alias] = model_state
+        await self.track_model(
+            alias, 
+            model_name=self._init_model_name or self.default_model_name, 
+            cloud_name=self._init_cloud_name,
+            keep=self._init_model_name is not None,
+        )
+
         self._current_alias = alias
 
     async def track_model(

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -708,8 +708,8 @@ class OpsTest:
             await self._controller.connect(self.controller_name)
 
         await self.track_model(
-            alias, 
-            model_name=self._init_model_name or self.default_model_name, 
+            alias,
+            model_name=self._init_model_name or self.default_model_name,
             cloud_name=self._init_cloud_name,
             keep=self._init_model_name is not None,
         )

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -510,6 +510,7 @@ async def test_fixture_set_up_existing_model(
     ops_test = plugin.OpsTest(setup_request, tmp_path_factory)
     assert ops_test.model is None
 
+    mock_juju.controller.list_models = AsyncMock(return_value=["this-model"])
     await ops_test._setup_model()
     mock_juju.model.connect.assert_called_with("this-controller:this-model")
     assert ops_test.model == mock_juju.model
@@ -552,7 +553,7 @@ async def test_fixture_set_up_automatic_model(
 
     await ops_test._setup_model()
     mock_juju.controller.add_model.assert_called_with(
-        model_name, "this-cloud", config=None
+        model_name, "this-cloud"
     )
     juju_cmd.assert_called_with(ops_test, "models")
     assert ops_test.model == mock_juju.model

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -276,7 +276,7 @@ async def test_plugin_fetch_resources(tmp_path_factory, resource_charm):
     arch_resources = ops_test.arch_specific_resources(resource_charm)
 
     def dl_rsc(resource, dest_path):
-        assert type(resource) == str
+        assert isinstance(resource, str)
         return dest_path
 
     with patch(
@@ -552,9 +552,7 @@ async def test_fixture_set_up_automatic_model(
     assert ops_test.model is None
 
     await ops_test._setup_model()
-    mock_juju.controller.add_model.assert_called_with(
-        model_name, "this-cloud"
-    )
+    mock_juju.controller.add_model.assert_called_with(model_name, "this-cloud")
     juju_cmd.assert_called_with(ops_test, "models")
     assert ops_test.model == mock_juju.model
     assert ops_test.model_full_name == f"this-controller:{model_name}"

--- a/tox.ini
+++ b/tox.ini
@@ -57,10 +57,10 @@ deps = -e {toxinidir}
 deps = {[integration]deps}
 commands = {[integration]commands}
 
-[testenv:integration-3.0]
+[testenv:integration-2.9]
 # run integration tests if bootstrapped with a juju 2.9 or juju 3.0 controller
 deps =
-    juju < 3.1
+    juju<3
     {[integration]deps}
 commands = {[integration]commands}
 


### PR DESCRIPTION
In response to the feature requested 
* https://github.com/charmed-kubernetes/pytest-operator/issues/110

If the `--model=<name>` switch is used with this plugin,  
* if that model doesn't exist -- create and keep that model after the tests
* reuse any existing model by this name

This should prevent errors like this when `--model=testing` is specfiied

```
juju.errors.JujuConnectionError: Model not found: admin/testing
```