### PR TITLE
Keep all packed charms, if there are more than one

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -1005,9 +1005,13 @@ class OpsTest:
                 f"Failed to build charm {charm_path}:\n{stderr}\n{stdout}"
             )
 
-        charm_file_src = next(charm_abs.glob(f"{charm_name}*.charm"))
-        charm_file_dst = charms_dst_dir / charm_file_src.name
-        charm_file_src.rename(charm_file_dst)
+        # If charmcraft.yaml has multiple bases, then multiple charms would be generated.
+        for charm_file_src in charm_abs.glob(f"{charm_name}*.charm"):
+            charm_file_dst = charms_dst_dir / charm_file_src.name
+            charm_file_src.rename(charm_file_dst)
+
+        # Even though we may have multiple *.charm file, for backwards compatibility we can
+        # only return one.
         return charm_file_dst
 
     async def build_charms(self, *charm_paths) -> Mapping[str, Path]:

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -930,7 +930,7 @@ class OpsTest:
         verbosity: Optional[
             Literal["quiet", "brief", "verbose", "debug", "trace"]
         ] = None,
-    ) -> Path:
+    ) -> Optional[Path]:
         """Builds a single charm.
 
         This can handle charms using the older charms.reactive framework as
@@ -1007,6 +1007,7 @@ class OpsTest:
 
         # If charmcraft.yaml has multiple bases
         # then multiple charms would be generated.
+        charm_file_dst = None
         for charm_file_src in charm_abs.glob(f"{charm_name}*.charm"):
             charm_file_dst = charms_dst_dir / charm_file_src.name
             charm_file_src.rename(charm_file_dst)

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -1005,13 +1005,14 @@ class OpsTest:
                 f"Failed to build charm {charm_path}:\n{stderr}\n{stdout}"
             )
 
-        # If charmcraft.yaml has multiple bases, then multiple charms would be generated.
+        # If charmcraft.yaml has multiple bases
+        # then multiple charms would be generated.
         for charm_file_src in charm_abs.glob(f"{charm_name}*.charm"):
             charm_file_dst = charms_dst_dir / charm_file_src.name
             charm_file_src.rename(charm_file_dst)
 
-        # Even though we may have multiple *.charm file, for backwards compatibility we can
-        # only return one.
+        # Even though we may have multiple *.charm file,
+        # for backwards compatibility we can - only return one.
         return charm_file_dst
 
     async def build_charms(self, *charm_paths) -> Mapping[str, Path]:


### PR DESCRIPTION
When `charmcraft.yaml` has multiple bases, then multiple *.charm files are created.
Before this PR, `build_charm` kept only one charm file:

```
find . -type f -name "*.charm"
./.tox/integration/tmp/pytest/test-juju-info-l4uc0/charms/grafana-agent_ubuntu-20.04-amd64.charm
```

With this PR we'd keep all *.charm files.
```
find . -type f -name "*.charm" 
./.tox/integration/tmp/pytest/test-juju-info-9fz20/charms/grafana-agent_ubuntu-20.04-amd64.charm
./.tox/integration/tmp/pytest/test-juju-info-9fz20/charms/grafana-agent_ubuntu-22.04-amd64.charm
```

Usage example:
- https://github.com/canonical/grafana-agent-operator/pull/9