### PR TITLE
Re-introduce model-config

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -712,6 +712,7 @@ class OpsTest:
             model_name=self._init_model_name or self.default_model_name,
             cloud_name=self._init_cloud_name,
             keep=self._init_model_name is not None,
+            config=self.read_model_config(self._init_model_config),
         )
 
         self._current_alias = alias

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -552,7 +552,9 @@ async def test_fixture_set_up_automatic_model(
     assert ops_test.model is None
 
     await ops_test._setup_model()
-    mock_juju.controller.add_model.assert_called_with(model_name, "this-cloud")
+    mock_juju.controller.add_model.assert_called_with(
+        model_name, "this-cloud", config=None
+    )
     juju_cmd.assert_called_with(ops_test, "models")
     assert ops_test.model == mock_juju.model
     assert ops_test.model_full_name == f"this-controller:{model_name}"


### PR DESCRIPTION
reading of the provided model-config was dropped in a previous refactor.  Adding that back in


Addresses https://github.com/charmed-kubernetes/pytest-operator/issues/117
