### PR TITLE
fix: pin pytest-asyncio<0.23

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         "ipdb",
         "pytest",
-        "pytest-asyncio",
+        "pytest-asyncio<0.23",
         "pyyaml",
         "juju",
         "jinja2",


### PR DESCRIPTION
applied as a temporary fix for possibly breaking changes introduced by pytest-asyncio>=0.23