### PR TITLE
Enable reading charm name from charmcraft.yaml

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -946,7 +946,10 @@ class OpsTest:
         metadata_path = charm_path / "metadata.yaml"
         layer_path = charm_path / "layer.yaml"
         charmcraft_path = charm_path / "charmcraft.yaml"
-        charm_name = yaml.safe_load(metadata_path.read_text())["name"]
+        if metadata_path.exists():
+            charm_name = yaml.safe_load(metadata_path.read_text())["name"]
+        else:
+            charm_name = yaml.safe_load(charmcraft_path.read_text())["name"]
         if layer_path.exists() and not charmcraft_path.exists():
             # Handle older, reactive framework charms.
             # if a charmcraft.yaml file isn't defined for it

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -946,11 +946,15 @@ class OpsTest:
         metadata_path = charm_path / "metadata.yaml"
         layer_path = charm_path / "layer.yaml"
         charmcraft_path = charm_path / "charmcraft.yaml"
-        if metadata_path.exists():
+        charmcraft_yaml_exists = charmcraft_path.exists()
+        charm_name = None
+        if charmcraft_yaml_exists:
+            charmcraft_yaml = yaml.safe_load(charmcraft_path.read_text())
+            if "name" in charmcraft_yaml:
+                charm_name = charmcraft_yaml["name"]
+        if charm_name is None:
             charm_name = yaml.safe_load(metadata_path.read_text())["name"]
-        else:
-            charm_name = yaml.safe_load(charmcraft_path.read_text())["name"]
-        if layer_path.exists() and not charmcraft_path.exists():
+        if layer_path.exists() and not charmcraft_yaml_exists:
             # Handle older, reactive framework charms.
             # if a charmcraft.yaml file isn't defined for it
             check_deps("charm")


### PR DESCRIPTION
Charmcraft has been updated to read metadata information directly from the `charmcraft.yaml` file without a separate `metadata.yaml`. Update to `pytest-operator` to read metadata information from `charmcraft.yaml` when required. 

For further details, refer to the pull request https://github.com/canonical/charmcraft/pull/1126.