### PR TITLE
fix: adjust OpsTest.tmp_path to avoid os.sep

### DIFF
--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -117,7 +117,7 @@ def test_tmp_path(ops_test):
 
 async def test_tmp_path_nonpath_chars(ops_test):
     model_alias = f"user{os.sep}name"
-    new_model = await ops_test.track_model(model_alias)
+    await ops_test.track_model(model_alias)
     with ops_test.model_context(model_alias):
         assert os.sep not in ops_test.tmp_path
         await ops_test.forget_model(model_alias)

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -119,7 +119,7 @@ async def test_tmp_path_nonpath_chars(ops_test):
     model_alias = f"user{os.sep}name"
     await ops_test.track_model(model_alias)
     with ops_test.model_context(model_alias):
-        assert os.sep not in ops_test.tmp_path
+        assert os.sep not in str(ops_test.tmp_path)
         await ops_test.forget_model(model_alias)
 
 

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -115,6 +115,14 @@ def test_tmp_path(ops_test):
     assert ops_test.tmp_path.relative_to(tox_env_dir)
 
 
+async def test_tmp_path_nonpath_chars(ops_test):
+    model_alias = f"user{os.sep}name"
+    new_model = await ops_test.track_model(model_alias)
+    with ops_test.model_context(model_alias):
+        assert os.sep not in ops_test.tmp_path
+        await ops_test.forget_model(model_alias)
+
+
 async def test_run(ops_test):
     assert await ops_test.run("/bin/true") == (0, "", "")
     assert await ops_test.run("/bin/false") == (1, "", "")

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -60,6 +60,24 @@ def test_tmp_path_without_tox(request, pytester):
     result.assert_outcomes(passed=1)
 
 
+@patch.object(plugin.OpsTest, "default_model_name", "user/model")
+@patch.object(plugin.OpsTest, "_setup_model", AsyncMock())
+@patch.object(plugin.OpsTest, "_cleanup_models", AsyncMock())
+def test_tmp_path_with_nonpath_chars(pytester):
+    pytester.makepyfile(
+        f"""
+        import os
+        from pathlib import Path
+
+        os.environ.update(**{ENV})
+        async def test_with_tox(ops_test):
+            assert ops_test.tmp_path.name == "user_model0"
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
 async def test_destructive_mode(monkeypatch, tmp_path_factory):
     patch = monkeypatch.setattr
     patch(plugin.os, "getgroups", mock_getgroups := Mock(return_value=[]))


### PR DESCRIPTION
When generating the `tmp_path`, ensure that only characters from the model name that are safe for use in paths are used. This particularly covers the case where the model name is in the form `user/name`, like MAAS.

Fixes #123