### PR TITLE
Allow taking a crashdump with extra arguments

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -61,6 +61,14 @@ Sets whether to output a juju-crashdump after tests.  Options are:
 * legacy: (DEFAULT) dumps after a failed test if '--keep-models' is False
 * never: never dumps
 
+### `--crash-dump-args`
+
+Sets extra crashdump arguments if running crashdump
+* default arguments are not revokable
+* arguments will appear after the default arguments
+* arguments are shlex delimited
+
+
 ### `--crash-dump-output`
 
 Path to the directory where the `juju-crashdump` output will be stored. The default is

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -108,7 +108,7 @@ def pytest_addoption(parser: Parser):
         "--crash-dump-args",
         action="store",
         default="",
-        help="If crashdump is run, run with provided extra arguments."
+        help="If crashdump is run, run with provided extra arguments.",
     )
     parser.addoption(
         "--crash-dump-output",
@@ -804,7 +804,7 @@ class OpsTest:
             log.debug("juju-crashdump will use output dir `%s`", output_directory)
             args.append(f"-o={output_directory}")
 
-        user_args = self.crash_dump_args.split()
+        user_args = shlex.split(self.crash_dump_args)
         cmd = ["juju-crashdump"] + args + user_args
         try:
             return_code, _, __ = await self.run(*cmd)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(include=["pytest_operator"]),
     package_data={'pytest_operator': ['py.typed']},
     url="https://github.com/charmed-kubernetes/pytest-operator",
-    version="0.32.0",
+    version="0.33.0",
     zip_safe=True,
     install_requires=[
         "ipdb",

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -372,6 +372,7 @@ async def test_crash_dump_mode(
     mock_request = Mock(**{"module.__name__": "test"})
     mock_request.config.option.crash_dump = crash_dump
     mock_request.config.option.no_crash_dump = no_crash_dump
+    mock_request.config.option.crash_dump_args = ""
     mock_request.config.option.keep_models = keep_models
     ops_test = plugin.OpsTest(mock_request, tmp_path_factory)
     model = MagicMock()
@@ -396,12 +397,9 @@ async def test_crash_dump_mode(
         mock_run.assert_called_once_with(
             "juju-crashdump",
             "-s",
-            "-m",
-            "test:model",
-            "-a",
-            "debug-layer",
-            "-a",
-            "config",
+            "-m=test:model",
+            "-a=debug-layer",
+            "-a=config",
         )
     else:
         mock_run.assert_not_called()
@@ -413,6 +411,7 @@ def test_crash_dump_mode_invalid_input(monkeypatch, tmp_path_factory):
     patch(plugin.OpsTest, "run", AsyncMock(return_value=(0, "", "")))
     mock_request = Mock(**{"module.__name__": "test"})
     mock_request.config.option.crash_dump = "not-a-real-option"
+    mock_request.config.option.crash_dump_args = ""
     mock_request.config.option.no_crash_dump = False
     mock_request.config.option.keep_models = False
 
@@ -429,8 +428,10 @@ async def test_create_crash_dump(monkeypatch, tmp_path_factory):
 
     patch = monkeypatch.setattr
     patch(plugin.OpsTest, "run", mock_run)
+    mock_request = Mock(**{"module.__name__": "test"})
+    mock_request.config.option.crash_dump_args = ""
     patch(plugin, "log", mock_log := MagicMock())
-    ops_test = plugin.OpsTest(Mock(**{"module.__name__": "test"}), tmp_path_factory)
+    ops_test = plugin.OpsTest(mock_request, tmp_path_factory)
     await ops_test.create_crash_dump()
     mock_log.info.assert_any_call("juju-crashdump command was not found.")
 

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -372,7 +372,7 @@ async def test_crash_dump_mode(
     mock_request = Mock(**{"module.__name__": "test"})
     mock_request.config.option.crash_dump = crash_dump
     mock_request.config.option.no_crash_dump = no_crash_dump
-    mock_request.config.option.crash_dump_args = ""
+    mock_request.config.option.crash_dump_args = "-c --bug=1234567"
     mock_request.config.option.keep_models = keep_models
     ops_test = plugin.OpsTest(mock_request, tmp_path_factory)
     model = MagicMock()
@@ -400,6 +400,8 @@ async def test_crash_dump_mode(
             "-m=test:model",
             "-a=debug-layer",
             "-a=config",
+            "-c",
+            "--bug=1234567",
         )
     else:
         mock_run.assert_not_called()


### PR DESCRIPTION
Adds new `--crash-dump-args` as extra arguments to pass to `juju-crashdump`