### PR TITLE
Move integration tests to juju 2.9, 3.1, and 3.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,13 +48,13 @@ jobs:
       run: |
         mkdir -p tmp/
         mv $HOME/.local/state/charmcraft/log/* tmp/ | true
-        cp ${GITHUB_WORKSPACE}/pytest-operator/pytest-operator/.tox/integration*/tmp/*.charm tmp/ | true
+        cp ${GITHUB_WORKSPACE}/.tox/integration*/tmp/*.charm tmp/ | true
 
     - name: Upload debug artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: test-run-artifacts
+        name: test-run-artifacts-${{ matrix.juju }}
         path: tmp
 
   integration-test:
@@ -87,11 +87,12 @@ jobs:
       run: |
         mkdir -p tmp/
         mv $HOME/.local/state/charmcraft/log/* tmp/ | true
-        cp ${GITHUB_WORKSPACE}/pytest-operator/pytest-operator/.tox/integration*/tmp/*.charm tmp/ | true
+        shopt -s globstar
+        cp ${GITHUB_WORKSPACE}/.tox/integration*/tmp/**/*.charm tmp/ | true
 
     - name: Upload debug artifacts
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4
       with:
-        name: test-run-artifacts
+        name: test-run-artifacts-${{ matrix.juju }}
         path: tmp

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,7 @@ jobs:
       run: |
         mkdir -p tmp/
         mv $HOME/.local/state/charmcraft/log/* tmp/ | true
+        cp ${GITHUB_WORKSPACE}/pytest-operator/pytest-operator/.tox/integration*/tmp/*.charm tmp/ | true
 
     - name: Upload debug artifacts
       if: ${{ failure() }}
@@ -65,7 +66,7 @@ jobs:
         juju: ['3.1', '3.3']
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Python
       uses: actions/setup-python@v4
@@ -86,10 +87,11 @@ jobs:
       run: |
         mkdir -p tmp/
         mv $HOME/.local/state/charmcraft/log/* tmp/ | true
+        cp ${GITHUB_WORKSPACE}/pytest-operator/pytest-operator/.tox/integration*/tmp/*.charm tmp/ | true
 
     - name: Upload debug artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-run-artifacts
         path: tmp

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,7 @@ jobs:
       run: |
         mkdir -p tmp/
         mv $HOME/.local/state/charmcraft/log/* tmp/ | true
+        shopt -s globstar
         cp ${GITHUB_WORKSPACE}/.tox/integration*/tmp/*.charm tmp/ | true
 
     - name: Upload debug artifacts

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     needs:
       - call-inclusive-naming-check
 
-  integration-test-3-0:
+  integration-test-2-9:
     name: Integration test with juju
     runs-on: ubuntu-22.04
     timeout-minutes: 40
@@ -37,6 +37,7 @@ jobs:
     - name: Setup operator test environment
       uses: charmed-kubernetes/actions-operator@main
       with:
+        charm-channel: 3.x/stable
         juju-channel: ${{ matrix.juju }}/stable
 
     - name: Run integration tests
@@ -61,7 +62,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        juju: ['3.1', '3.2']
+        juju: ['3.1', '3.3']
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -74,6 +75,7 @@ jobs:
     - name: Setup operator test environment
       uses: charmed-kubernetes/actions-operator@main
       with:
+        charm-channel: 3.x/stable
         juju-channel: ${{ matrix.juju }}/stable
 
     - name: Run integration tests

--- a/tests/data/charms/reactive-framework/wheelhouse.txt
+++ b/tests/data/charms/reactive-framework/wheelhouse.txt
@@ -1,0 +1,1 @@
+sniffio<1.3.1  # 1.3.1 requires setuptools>=64


### PR DESCRIPTION
* Test with juju 2.9, 3.1, and 3.3
* Also use `charm-channel` `3.x/stable` to properly build reactive charms
* Pin sniffio<1.3.0 because after 2 years this dep finally decided it hated old `setuptools`
* archive built charms in the event that the tests fail