### PR TITLE
Add cos abstraction for testing grafana-agent-k8s

### DIFF
--- a/pytest_operator/cos.py
+++ b/pytest_operator/cos.py
@@ -1,0 +1,371 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utilities for testing COS integration with charms."""
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, Set
+
+import yaml
+from juju.action import Action
+from juju.application import Application
+from juju.model import Model
+from juju.relation import Relation
+from juju.unit import Unit
+
+log = logging.getLogger(__name__)
+
+GRAFANA_AGENT_APP = "grafana-agent-k8s"
+GRAFANA_AGENT_METRICS_ENDPOINT = "metrics-endpoint"
+GRAFANA_AGENT_GRAFANA_DASHBOARD = "grafana-dashboards-consumer"
+GRAFANA_AGENT_LOGGING_PROVIDER = "logging-provider"
+# Note(rgildein): The status message comes from the helper function `_update_status` in
+# grafana-agent-k8s, which is used to set the status based on the health of the
+# relation.
+# https://github.com/canonical/grafana-agent-operator/blob/1f2443dedc325f31b2cb02eefe0705afa6ac50e1/src/grafana_agent.py#L464  # noqa E503
+GRAFANA_AGENT_MESSAGE = re.compile(
+    r"Missing "
+    r"(?=.*\['grafana-cloud-config'\]|\['grafana-dashboards-provider'\] "
+    r"for grafana-dashboards-consumer)"
+    r"(?=.*\['grafana-cloud-config'\]|\['logging-consumer'\] for logging-provider)"
+    r"(?=.*\['grafana-cloud-config'\]|\['send-remote-write'\] for metrics-endpoint)"
+)
+
+APP_METRICS_ENDPOINT = "metrics-endpoint"
+APP_GRAFANA_DASHBOARD = "grafana-dashboard"
+APP_LOGGING = "logging"
+
+ALERT_RULES_DIRECTORY = Path("./src/prometheus_alert_rules")
+
+
+async def deploy_and_assert_grafana_agent(
+    model: Model,
+    app: str,
+    channel: str = "latest/stable",
+    metrics: bool = False,
+    logging: bool = False,
+    dashboard: bool = False,
+) -> None:
+    """Deploy grafana-agent-k8s and add relate it with app.
+
+    Helper function to deploy and relate grafana-agent-k8s with provided app.
+
+    Args:
+        model (juju.model.Model): Juju model object.
+        app (str): Name of application with which the Grafana agent should be related.
+        channel (str): Channel name for grafana-agent-k8s. Defaults to latest/stable.
+        metrics (bool): Boolean that defines if the <app>:metrics-endpoint
+            grafana-agent-k8s:metrics-endpoint relation is created. Defaults to False.
+        logging (bool): Boolean that defines if the <app>:logging
+            grafana-agent-k8s:logging-provider relation is created. Defaults to False.
+        dashboard (bool): Boolean that defines if the <app>:grafana-dashboard
+            grafana-agent-k8s:grafana-dashboards-consumer relation is created. Defaults
+            to False.
+    """
+    assert (
+        app in model.applications
+    ), f"application {app} was not found in model {model.name}"
+
+    log.info("deploying %s from %s channel", GRAFANA_AGENT_APP, channel)
+    await model.deploy(GRAFANA_AGENT_APP, channel=channel)
+
+    if dashboard is True:
+        log.info(
+            "Adding relation: %s:%s and %s:%s",
+            app,
+            APP_GRAFANA_DASHBOARD,
+            GRAFANA_AGENT_APP,
+            GRAFANA_AGENT_GRAFANA_DASHBOARD,
+        )
+        await model.integrate(
+            f"{app}:{APP_GRAFANA_DASHBOARD}",
+            f"{GRAFANA_AGENT_APP}:{GRAFANA_AGENT_GRAFANA_DASHBOARD}",
+        )
+
+    if metrics is True:
+        log.info(
+            "Adding relation: %s:%s and %s:%s",
+            app,
+            APP_METRICS_ENDPOINT,
+            GRAFANA_AGENT_APP,
+            GRAFANA_AGENT_METRICS_ENDPOINT,
+        )
+        await model.integrate(
+            f"{app}:{APP_METRICS_ENDPOINT}",
+            f"{GRAFANA_AGENT_APP}:{GRAFANA_AGENT_METRICS_ENDPOINT}",
+        )
+
+    if logging is True:
+        log.info(
+            "Adding relation: %s:%s and %s:%s",
+            app,
+            APP_LOGGING,
+            GRAFANA_AGENT_APP,
+            GRAFANA_AGENT_LOGGING_PROVIDER,
+        )
+        await model.integrate(
+            f"{app}:{APP_LOGGING}",
+            f"{GRAFANA_AGENT_APP}:{GRAFANA_AGENT_LOGGING_PROVIDER}",
+        )
+
+    # Note(rgildein): Since we are not deploying cos, grafana-agent-k8s will in block
+    # state with missing relations.
+    await model.wait_for_idle(
+        apps=[GRAFANA_AGENT_APP], status="blocked", timeout=5 * 60
+    )
+    for unit in model.applications[GRAFANA_AGENT_APP].units:
+        _assert_grafana_agent_status(unit.workload_status_message)
+
+
+def _assert_grafana_agent_status(status: str) -> None:
+    """Check status of grafana-agent."""
+    error_msg = (
+        f"{GRAFANA_AGENT_APP} did not reach expected state. '{status}' != "
+        f"'{GRAFANA_AGENT_MESSAGE.pattern}'"
+    )
+    assert GRAFANA_AGENT_MESSAGE.match(status), error_msg
+
+
+async def _check_metrics_endpoint(app: Application, metrics_endpoint: str) -> None:
+    """Check metrics endpoint accessibility.
+
+    Checking accessibility of metrics endpoint from grafana-agent-k8s. If metrics
+    endpoint is defined as `*:5000/metrics` it will be changed to
+    `<app-name>.<namespace>.svc:5000/metrics`.
+    """
+    if metrics_endpoint.startswith("*"):
+        url = f"http://{app.name}.{app.model.name}.svc{metrics_endpoint[1:]}"
+    else:
+        url = f"http://{metrics_endpoint}"
+
+    cmd = f"curl -m 5 -sS {url}"
+    grafana_agent_app = app.model.applications[GRAFANA_AGENT_APP]
+    log.info("testing metrics endpoint with cmd: `%s`", cmd)
+    for unit in grafana_agent_app.units:
+        await _run_on_unit(unit, cmd)
+
+
+async def _get_relation(app: Application, endpoint_name: str) -> Relation:
+    """Get relation for endpoint."""
+    assert len(app.units) > 0, f"application {app.name} has no units"
+    relations = [
+        relation
+        for relation in app.relations
+        if any(endpoint.name == endpoint_name for endpoint in relation.endpoints)
+    ]
+    log.info("found relations %s for %s:%s", relations, app.name, endpoint_name)
+
+    assert not (len(relations) == 0), f"{endpoint_name} is missing"
+    assert not (len(relations) > 1), f"too many relations with {endpoint_name} endpoint"
+    return relations[0]
+
+
+async def _get_app_relation_data(
+    app: Application, endpoint_name: str
+) -> Dict[str, Any]:
+    """Get application relation data from endpoint name."""
+    relation = await _get_relation(app, endpoint_name)
+    unit = app.units[
+        0
+    ]  # Note(rgildein) use first unit, since we are getting application data
+    cmd = f"relation-get --format=yaml -r {relation.entity_id} --app - {app.name}"
+    result = await _run_on_unit(unit, cmd)
+
+    return yaml.safe_load(result.results["stdout"])
+
+
+async def _get_unit_relation_data(
+    app: Application, endpoint_name: str
+) -> Dict[str, Dict[str, Any]]:
+    """Get units relation data from endpoint name."""
+    relation = await _get_relation(app, endpoint_name)
+    data = {}
+    for unit in app.units:
+        cmd = f"relation-get --format=yaml -r {relation.entity_id} - {unit.name}"
+        result = await _run_on_unit(unit, cmd)
+        data[unit.name] = yaml.safe_load(result.results["stdout"])
+
+    return data
+
+
+def _get_alert_rules(data: str) -> Set[str]:
+    """Get all alert rules from string, e.g. file content or relation data.
+
+    Example of relations data of metrics-endpoint would be:
+
+    ```Python
+    'alert_rules': '{"groups": [{rules": [{"alert": "my-alert", ...
+    ```
+
+    Example of rule file with single alert rule:
+
+    ```yaml
+    alert: my-alert
+    expr: up < 1
+    for: 5m
+    ...
+    ```
+
+    Example of rule file with multiple alert rules:
+
+    ```yaml
+    groups:
+    - name: my-group
+      rules:
+      - alert: my-alert
+    ...
+    ```
+    """
+    alert_rules = yaml.safe_load(data)
+    if "groups" in alert_rules:
+        return {
+            rule["alert"] for group in alert_rules["groups"] for rule in group["rules"]
+        }
+
+    return {alert_rules["alert"]}
+
+
+def _get_metrics_endpoint(data: str) -> Set[str]:
+    """Get set of metrics endpoints from string.
+
+    This function is expecting data defined as string.
+
+    ```json
+    [
+      {
+        "metrics_path": "/metrics",
+        "static_configs": [
+          {
+            "targets": [
+              "*:5000",
+              "*:8000"
+            ]
+          }
+        ]
+      }
+    ]
+    ```
+    """
+    metrics_endpoints = set()
+    scrape_jobs = yaml.safe_load(data)
+    for job in scrape_jobs:
+        path = job["metrics_path"]
+        metrics_endpoints |= {
+            f"{target}{path}"
+            for config in job["static_configs"]
+            for target in config["targets"]
+        }
+
+    return metrics_endpoints
+
+
+async def _run_on_unit(unit: Unit, cmd: str) -> Action:
+    """Run command on unit."""
+    log.info("running cmd `%s` on unit %s", cmd, unit.name)
+    result = await unit.run(
+        cmd, block=True
+    )  # Note(rgildein): Using block to wait for results
+
+    assert (
+        result.results["return-code"] == 0
+    ), f"cmd `{cmd}` failed with error `{result.results.get('stderr')}`"
+    return result
+
+
+def get_alert_rules(path: Path = ALERT_RULES_DIRECTORY) -> Set[str]:
+    """Get all alert rules from files.
+
+    Args:
+        path (Path): Path of alert rules directory. Defaults to
+        "./src/prometheus_alert_rules".
+
+    Returns:
+        set[str]: Set with all alert rules.
+    """
+    alert_rules = set()
+    for file_type in ["*.rule", "*.rules"]:
+        for file in path.glob(file_type):
+            alert_rules |= _get_alert_rules(file.read_text())
+
+    return alert_rules
+
+
+async def assert_alert_rules(app: Application, alert_rules: Set[str]) -> None:
+    """Check alert rules in relation data bag.
+
+    This function compare alert rules defined in APP_METRICS_ENDPOINT relation data bag
+    and provided alert rules. e.g. {"my-alert1", "my-alert2"}
+
+    Args:
+        app (Application): Juju Applicatition object.
+        alert_rules (set[str]): Set of alert rules.
+    """
+    relation_data = await _get_app_relation_data(app, APP_METRICS_ENDPOINT)
+    assert (
+        "alert_rules" in relation_data
+    ), f"{APP_METRICS_ENDPOINT} relation is missing 'alert_rules'"
+
+    relation_alert_rules = _get_alert_rules(relation_data["alert_rules"])
+
+    assert (
+        relation_alert_rules == alert_rules
+    ), f"{relation_alert_rules}\n!=\n{alert_rules}"
+
+
+async def assert_metrics_endpoint(
+    app: Application, metrics_port: int, metrics_path: str, metrics_target: str = "*"
+) -> None:
+    """Check the endpoint in the relation data bag and verify its accessibility.
+
+    This function compare metrics endpoints defined in APP_METRICS_ENDPOINT relation
+    data bag and provided metrics endpoint.
+    e.g. `metrics_port=5000, metrics_path="/metrics"
+    At the same time it will check the accessibility of such endpoint from
+    grafana-agent-k8s pod.
+
+    Args:
+        app (Application): Juju Applicatition object.
+        metrics_port (int): Metrics port to verify.
+        metrics_path (str): Metrics path to verify.
+        metrics_target (str): Metrics target to verify. Defaults to '*'.
+    """
+    relation_data = await _get_app_relation_data(app, APP_METRICS_ENDPOINT)
+    assert (
+        "scrape_jobs" in relation_data
+    ), f"{APP_METRICS_ENDPOINT} relation is missing 'scrape_jobs'"
+
+    relation_metrics_endpoints = _get_metrics_endpoint(relation_data["scrape_jobs"])
+
+    metrics_endpoint = f"{metrics_target}:{metrics_port}{metrics_path}"
+
+    assert (
+        metrics_endpoint in relation_metrics_endpoints
+    ), f"{metrics_endpoint} not in {relation_metrics_endpoints}"
+    await _check_metrics_endpoint(app, metrics_endpoint)
+
+
+async def assert_logging(app: Application) -> None:
+    """Check defined logging settings in relation data bag.
+
+    This function checks if endpoint is defined in logging relation data bag, the unit
+    relation data bag and not application.. e.g.
+    ```yaml
+    related-units:
+      grafana-agent-k8s/0:
+        in-scope: true
+        data:
+          endpoint: |
+            '{"url": "http://grafana-agent-k8s-0.grafana-agent-k8s-endpoints.
+            my-model.svc.cluster.local:3500/loki/api/v1/push"}'
+          ...
+    ```
+
+    Args:
+        app (Application): Juju Applicatition object.
+    """
+    unit_relation_data = await _get_unit_relation_data(app, APP_LOGGING)
+    for unit_name, unit_data in unit_relation_data.items():
+        assert (
+            "endpoint" in unit_data
+        ), f"{APP_LOGGING} unit '{unit_name}' relation data are missing 'endpoint'"

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -53,6 +53,8 @@ from juju.exceptions import DeadEntityException
 from juju.errors import JujuError
 from juju.model import Model, Controller, websockets
 
+from pytest_operator.cos import deploy_and_assert_grafana_agent
+
 log = logging.getLogger(__name__)
 
 
@@ -1666,3 +1668,19 @@ class OpsTest:
         log.info(f"Forgetting cloud: {cloud_name}...")
         await self._controller.remove_cloud(cloud_name)
         del self._clouds[cloud_name]
+
+    async def deploy_and_assert_grafana_agent(
+        self,
+        app: str,
+        channel: str = "latest/stable",
+        metrics: bool = False,
+        logging: bool = False,
+        dashboard: bool = False,
+    ) -> None:
+        """Deploy grafana-agent-k8s and add relate it with app.
+
+        Helper function to deploy and relate grafana-agent-k8s with provided app.
+        """
+        await deploy_and_assert_grafana_agent(
+            self.model, app, channel, metrics, logging, dashboard
+        )

--- a/tests/integration/test_cos.py
+++ b/tests/integration/test_cos.py
@@ -1,0 +1,65 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+
+import pytest_operator.cos
+from pytest_operator.cos import (
+    GRAFANA_AGENT_APP,
+    assert_alert_rules,
+    assert_logging,
+    assert_metrics_endpoint,
+)
+
+# Note(rgildein): Change app metrics endpoint, since blackbox-exporter-k8s is not using
+# 'metrics-endpoint'.
+pytest_operator.cos.APP_METRICS_ENDPOINT = "self-metrics-endpoint"
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy(ops_test):
+    """Test deployment of grafana-agent-k8s and relate it with charm."""
+    await ops_test.model.deploy(
+        "blackbox-exporter-k8s", channel="latest/stable", trust=True
+    )
+    await ops_test.model.wait_for_idle(raise_on_blocked=True)
+
+    await ops_test.deploy_and_assert_grafana_agent(
+        "blackbox-exporter-k8s",
+        metrics=True,
+        dashboard=True,
+        logging=True,
+    )
+
+
+async def test_alert_rules(ops_test):
+    """Test alert_rules are defined in relation data bag."""
+    app = ops_test.model.applications["blackbox-exporter-k8s"]
+    await assert_alert_rules(
+        app,
+        {
+            "BlackboxJobMissing",
+            "BlackboxExporterSSLCertExpiringSoon",
+            "BlackboxExporterUnitIsUnavailable",
+            "BlackboxExporterUnitIsDown",
+        },
+    )
+
+
+async def test_metrics_endpoints(ops_test):
+    """Test metrics_endpoints are defined in relation data bag."""
+    app = ops_test.model.applications["blackbox-exporter-k8s"]
+    await assert_metrics_endpoint(
+        app,
+        metrics_port=9115,
+        metrics_path="/metrics",
+        metrics_target="blackbox-exporter-k8s-0.blackbox-exporter-k8s-endpoints."
+        f"{ops_test.model.name}.svc.cluster.local",
+    )
+
+
+async def test_logging(ops_test):
+    """Test logging is defined in relation data bag."""
+    app = ops_test.model.applications[GRAFANA_AGENT_APP]
+    await assert_logging(app)

--- a/tests/unit/test_cos.py
+++ b/tests/unit/test_cos.py
@@ -1,0 +1,521 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import AsyncMock, Mock, call, patch
+
+import pytest
+from juju.action import Action
+from juju.application import Application
+from juju.model import Model
+from juju.relation import Endpoint, Relation
+from juju.unit import Unit
+
+from pytest_operator.cos import (
+    _assert_grafana_agent_status,
+    _check_metrics_endpoint,
+    _get_alert_rules,
+    _get_app_relation_data,
+    _get_metrics_endpoint,
+    _get_relation,
+    _get_unit_relation_data,
+    _run_on_unit,
+    assert_alert_rules,
+    assert_logging,
+    assert_metrics_endpoint,
+    deploy_and_assert_grafana_agent,
+    get_alert_rules,
+)
+
+EXP_GRAFANA_AGENT_MSG = (
+    "Missing ['grafana-cloud-config']|['grafana-dashboards-provider'] for "
+    "grafana-dashboards-consumer; ['grafana-cloud-config']|['logging-consumer'] for "
+    "logging-provider; ['grafana-cloud-config']|['send-remote-write'] for "
+    "metrics-endpoint"
+)
+MY_ALERT_1 = """
+groups:
+- name: my-server
+  rules:
+  - alert: MyAlert1
+    expr: rate(http_request_duration_seconds_sum[5m]) > 7
+    for: 0m
+    labels:
+      severity: critical
+    annotations:
+      summary: MyServer server {{ $labels.juju_model }}/{{ $labels.juju_unit }} requests taking longer than expected
+      description: >
+        The MyServer server {{ $labels.juju_model }} {{ $labels.juju_unit }} requests taking longer than 7 seconds in the last 5 min window
+        LABELS = {{ $labels }}
+"""  # noqa E503
+MY_ALERT_2 = """
+alert: MyAlert2
+expr: up < 1
+for: 5m
+labels:
+  severity: critical
+annotations:
+  summary: MyServer unit {{ $labels.juju_model }}/{{ $labels.juju_unit }} unavailable
+  description: >
+    The MyServer unit {{ $labels.juju_model }} {{ $labels.juju_unit }} is unavailable
+    LABELS = {{ $labels }}
+"""  # noqa E503
+
+
+@pytest.mark.asyncio
+async def test_deploy_and_assert_grafana_agent_invalid_app():
+    """Test deploy grafana-agent-k8s along not existing app."""
+    app = "my-app"
+    model = AsyncMock(spec_set=Model)
+    model.applications = []
+
+    with pytest.raises(AssertionError, match=f"application {app} was not found"):
+        await deploy_and_assert_grafana_agent(model, app)
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        EXP_GRAFANA_AGENT_MSG,
+        "Missing ['grafana-cloud-config']|['grafana-dashboards-provider'] for "
+        "grafana-dashboards-consumer",
+        "Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider",
+        "Missing ['grafana-cloud-config']|['send-remote-write'] for metrics-endpoint",
+    ],
+)
+def test_assert_grafana_agent_msg(msg):
+    """Test all possible grafana-agent-k8s expected msg."""
+    _assert_grafana_agent_status(msg)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs, exp_awaits",
+    [
+        (
+            {"metrics": True, "dashboard": True, "logging": True},
+            [
+                call(
+                    "my-app:grafana-dashboard",
+                    "grafana-agent-k8s:grafana-dashboards-consumer",
+                ),
+                call("my-app:metrics-endpoint", "grafana-agent-k8s:metrics-endpoint"),
+                call("my-app:logging", "grafana-agent-k8s:logging-provider"),
+            ],
+        ),
+        (
+            {"metrics": True, "dashboard": True, "logging": False},
+            [
+                call(
+                    "my-app:grafana-dashboard",
+                    "grafana-agent-k8s:grafana-dashboards-consumer",
+                ),
+                call("my-app:metrics-endpoint", "grafana-agent-k8s:metrics-endpoint"),
+            ],
+        ),
+        (
+            {"metrics": True, "dashboard": False, "logging": True},
+            [
+                call("my-app:metrics-endpoint", "grafana-agent-k8s:metrics-endpoint"),
+                call("my-app:logging", "grafana-agent-k8s:logging-provider"),
+            ],
+        ),
+        (
+            {"metrics": True, "dashboard": False, "logging": False},
+            [
+                call("my-app:metrics-endpoint", "grafana-agent-k8s:metrics-endpoint"),
+            ],
+        ),
+        ({"dashboard": False, "metrics": False, "logging": False}, []),
+    ],
+)
+async def test_deploy_and_assert_grafana_agent(kwargs, exp_awaits):
+    """Test deploy grafana-agent-k8s along test app."""
+    app = Mock(spec_set=Application)()
+    app.name = "my-app"
+
+    grafana_aget_app = Mock(spec_set=Application)()
+    grafana_aget_app.name = "grafana-agent-k8s"
+    grafana_aget_unit = Mock(spec_set=Unit)()
+    grafana_aget_unit.workload_status_message = EXP_GRAFANA_AGENT_MSG
+    grafana_aget_app.units = [grafana_aget_unit]
+
+    model = AsyncMock(spec_set=Model)
+    model.applications = {app.name: app, grafana_aget_app.name: grafana_aget_app}
+
+    await deploy_and_assert_grafana_agent(model, app.name, **kwargs)
+
+    model.deploy.assert_awaited_once_with("grafana-agent-k8s", channel="latest/stable")
+    model.integrate.assert_has_awaits(exp_awaits)
+    model.wait_for_idle.assert_awaited_once_with(
+        apps=["grafana-agent-k8s"], status="blocked", timeout=300
+    )
+
+
+@pytest.mark.asyncio
+async def test_deploy_and_assert_grafana_agent_failed():
+    """Test deploy grafana-agent-k8s failed reached expected state."""
+    exp_error_msg = (
+        "grafana-agent-k8s did not reach expected state. 'different message' != .*"
+    )
+    app = Mock(spec_set=Application)()
+    app.name = "my-app"
+
+    grafana_aget_app = Mock(spec_set=Application)()
+    grafana_aget_app.name = "grafana-agent-k8s"
+    grafana_aget_unit = Mock(spec_set=Unit)()
+    grafana_aget_unit.workload_status_message = "different message"
+    grafana_aget_app.units = [grafana_aget_unit]
+
+    model = AsyncMock(spec_set=Model)
+    model.applications = {app.name: app, grafana_aget_app.name: grafana_aget_app}
+
+    with pytest.raises(AssertionError, match=exp_error_msg):
+        await deploy_and_assert_grafana_agent(model, app.name)
+
+    model.deploy.assert_awaited_once_with("grafana-agent-k8s", channel="latest/stable")
+
+
+@pytest.mark.asyncio
+async def test_get_relation_no_relations():
+    """Test getting not existing relation."""
+    app = Mock(spec_set=Application)()
+    unit = Mock(spec_set=Unit)()
+    app.name = "my-app"
+    app.units = [unit]
+    relation = Mock(spec_set=Relation)()
+    endpoint = Mock(spec_set=Endpoint)()
+    endpoint.name = "different-endpoint"
+    relation.endpoints = [endpoint]
+    app.relations = [relation]
+
+    with pytest.raises(AssertionError, match="metrics-endpoint is missing"):
+        await _get_relation(app, "metrics-endpoint")
+
+
+@pytest.mark.asyncio
+async def test_get_relation_too_many():
+    """Test getting relation, when there is too many of them."""
+    app = Mock(spec_set=Application)()
+    unit = Mock(spec_set=Unit)()
+    app.name = "my-app"
+    app.units = [unit]
+    relation = Mock(spec_set=Relation)()
+    endpoint = Mock(spec_set=Endpoint)()
+    endpoint.name = "metrics-endpoint"
+    relation.endpoints = [endpoint]
+    app.relations = [relation] * 3  # three relations
+
+    with pytest.raises(
+        AssertionError, match="too many relations with metrics-endpoint endpoint"
+    ):
+        await _get_relation(app, "metrics-endpoint")
+
+
+@pytest.mark.asyncio
+async def test_get_relation():
+    """Test getting relation."""
+    app = Mock(spec_set=Application)()
+    unit = Mock(spec_set=Unit)()
+    app.name = "my-app"
+    app.units = [unit]
+    relation = Mock(spec_set=Relation)()
+    endpoint = Mock(spec_set=Endpoint)()
+    endpoint.name = "metrics-endpoint"
+    relation.endpoints = [endpoint]
+    app.relations = [relation]
+
+    assert await _get_relation(app, "metrics-endpoint") == relation
+
+
+@pytest.mark.asyncio
+async def test_get_app_relation_data_no_units():
+    """Test getting application data from relation data bag without units."""
+    app = Mock(spec_set=Application)()
+    app.name = "my-app"
+    app.units = []
+
+    with pytest.raises(AssertionError, match="application my-app has no units"):
+        await _get_app_relation_data(app, "metrics-endpoint")
+
+
+@pytest.mark.asyncio
+@patch("pytest_operator.cos._get_relation")
+@patch("pytest_operator.cos._run_on_unit")
+@patch("pytest_operator.cos.yaml")
+async def test_get_app_relation_data(mock_yaml, mock_run_on_unit, mock_get_relation):
+    """Test getting application data from relation data bag."""
+    relation = Mock(spec_set=Relation)()
+    relation.entity_id = relation_id = 7
+    mock_get_relation.return_value = relation
+    app = Mock(spec_set=Application)()
+    unit = Mock(spec_set=Unit)()
+    app.name = "my-app"
+    app.units = [unit]
+    mock_run_on_unit.return_value = result = Mock(spec_set=Action)()
+    result.results = {"stdout": "test"}
+
+    data = await _get_app_relation_data(app, "metrics-endpoint")
+
+    mock_run_on_unit.assert_awaited_once_with(
+        unit, f"relation-get --format=yaml -r {relation_id} --app - {app.name}"
+    )
+    mock_yaml.safe_load.assert_called_once_with("test")
+    assert data == mock_yaml.safe_load.return_value
+
+
+@pytest.mark.asyncio
+@patch("pytest_operator.cos._get_relation")
+@patch("pytest_operator.cos._run_on_unit")
+@patch("pytest_operator.cos.yaml")
+async def test_get_unit_relation_data(mock_yaml, mock_run_on_unit, mock_get_relation):
+    """Test getting unit data from relation data bag."""
+    relation = Mock(spec_set=Relation)()
+    relation.entity_id = relation_id = 7
+    mock_get_relation.return_value = relation
+    app = Mock(spec_set=Application)()
+    unit = Mock(spec_set=Unit)()
+    unit.name = "my-app/0"
+    app.name = "my-app"
+    app.units = [unit]
+    mock_run_on_unit.return_value = result = Mock(spec_set=Action)()
+    result.results = {"stdout": "test"}
+
+    data = await _get_unit_relation_data(app, "metrics-endpoint")
+
+    mock_run_on_unit.assert_awaited_once_with(
+        unit, f"relation-get --format=yaml -r {relation_id} - {unit.name}"
+    )
+    mock_yaml.safe_load.assert_called_once_with("test")
+    assert data == {unit.name: mock_yaml.safe_load.return_value}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "metrics_endpoint, exp_cmd",
+    [
+        ("*:5000/metrics", "curl -m 5 -sS http://my-app.my-model.svc:5000/metrics"),
+        ("1.2.3.4:5000/metrics", "curl -m 5 -sS http://1.2.3.4:5000/metrics"),
+    ],
+)
+@patch("pytest_operator.cos._run_on_unit")
+async def test_check_metrics_endpoint(mock_run_on_unit, metrics_endpoint, exp_cmd):
+    """Test check metrics endpoints."""
+    grafana_agent_k8s_app = Mock(spec_set=Application)()
+    unit = Mock(spec_set=Unit)()
+    grafana_agent_k8s_app.units = [unit]
+
+    app = Mock(spec_set=Application)()
+    app.name = "my-app"
+    app.model = AsyncMock(spec_set=Model)
+    app.model.name = "my-model"
+    app.model.applications = {"grafana-agent-k8s": grafana_agent_k8s_app, "my-app": app}
+
+    await _check_metrics_endpoint(app, metrics_endpoint)
+
+    mock_run_on_unit.assert_awaited_once_with(unit, exp_cmd)
+
+
+@pytest.mark.parametrize(
+    "data, exp_alert_rules",
+    [
+        ('{"groups": [{"rules": [{"alert": "my-alert"}]}]}', {"my-alert"}),
+        ("alert: my-alert\nexpr: up < 1\nfor: 5m", {"my-alert"}),
+        (
+            "groups:\n- name: my-group1\n  rules:\n  - alert: my-alert1\n"
+            "- name: my-group2\n  rules:\n  - alert: my-alert2",
+            {"my-alert1", "my-alert2"},
+        ),
+    ],
+)
+def test_get_alert_rules_from_string(data, exp_alert_rules):
+    """Test helper function to get alert rules from string."""
+    assert _get_alert_rules(data) == exp_alert_rules
+
+
+@pytest.mark.parametrize(
+    "data, exp_metrics_endpoint",
+    [
+        (
+            '[{"metrics_path": "/metrics", "static_configs": [{"targets": '
+            '["*:5000","*:8000"]}]}]',
+            {"*:5000/metrics", "*:8000/metrics"},
+        ),
+    ],
+)
+def test_get_metrics_endpoint(data, exp_metrics_endpoint):
+    """Test helper function to get metrics endpoints from string."""
+    assert _get_metrics_endpoint(data) == exp_metrics_endpoint
+
+
+@pytest.mark.asyncio
+async def test_run_on_unit_fail():
+    """Test run cmd on unit with failure."""
+    unit = Mock(spec_set=Unit)()
+    unit.name = "my-app/0"
+    unit.run = mock_result = AsyncMock(spec_set=Unit.run)
+    mock_result.return_value.results = {"return-code": 1}
+
+    with pytest.raises(AssertionError, match="cmd `test` failed with error `None`"):
+        await _run_on_unit(unit, "test")
+
+
+@pytest.mark.asyncio
+async def test_run_on_unit():
+    """Test run cmd on unit."""
+    unit = Mock(spec_set=Unit)()
+    unit.name = "my-app/0"
+    unit.run = AsyncMock()
+    unit.run.return_value.results = {"return-code": 0}
+
+    result = await _run_on_unit(unit, "test")
+
+    assert result == unit.run.return_value
+    unit.run.assert_awaited_once_with("test", block=True)
+
+
+@pytest.mark.asyncio
+@patch("pytest_operator.cos._get_app_relation_data")
+@patch("pytest_operator.cos._get_alert_rules")
+async def test_assert_alert_rules_no_data(
+    mock_get_alert_rules, mock_get_app_relation_data
+):
+    """Test assert function for alert rules with empty data bag."""
+    app = Mock(spec_set=Application)()
+    mock_get_app_relation_data.return_value = {}
+
+    with pytest.raises(
+        AssertionError, match="metrics-endpoint relation is missing 'alert_rules'"
+    ):
+        await assert_alert_rules(app, {})
+
+    mock_get_app_relation_data.assert_awaited_once_with(app, "metrics-endpoint")
+    mock_get_alert_rules.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("pytest_operator.cos._get_app_relation_data")
+@patch("pytest_operator.cos._get_alert_rules")
+async def test_assert_alert_rules(mock_get_alert_rules, mock_get_app_relation_data):
+    """Test assert function for alert rules."""
+    app = Mock(spec_set=Application)()
+    mock_get_app_relation_data.return_value = {"alert_rules": "..."}
+    mock_get_alert_rules.return_value = exp_alert_rules = {"my-alert1", "my-alert2"}
+
+    await assert_alert_rules(app, exp_alert_rules)
+
+    mock_get_app_relation_data.assert_awaited_once_with(app, "metrics-endpoint")
+    mock_get_alert_rules.assert_called_once_with("...")
+
+
+@pytest.mark.asyncio
+@patch("pytest_operator.cos._get_app_relation_data")
+@patch("pytest_operator.cos._get_alert_rules")
+async def test_assert_alert_rules_fail(
+    mock_get_alert_rules, mock_get_app_relation_data
+):
+    """Test assert function for alert rules failing."""
+    app = Mock(spec_set=Application)()
+    mock_get_app_relation_data.return_value = {"alert_rules": "..."}
+    mock_get_alert_rules.return_value = {"my-alert1", "my-alert2"}
+
+    with pytest.raises(AssertionError):
+        await assert_alert_rules(app, {"different-alert"})
+
+    mock_get_app_relation_data.assert_awaited_once_with(app, "metrics-endpoint")
+    mock_get_alert_rules.assert_called_once_with("...")
+
+
+@pytest.mark.asyncio
+@patch("pytest_operator.cos._get_app_relation_data")
+@patch("pytest_operator.cos._get_metrics_endpoint")
+@patch("pytest_operator.cos._check_metrics_endpoint")
+async def test_assert_metrics_endpoint_empty_data_bag(
+    mock_check_metrics_endpoint, mock_get_metrics_endpoint, mock_get_app_relation_data
+):
+    """Test assert function for metrics endpoint with empty data bag."""
+    exp_error_msg = (
+        "metrics-endpoint relation is missing 'scrape_jobs'\nassert 'scrape_jobs' in {}"
+    )
+    app = Mock(spec_set=Application)()
+    mock_get_app_relation_data.return_value = {}
+
+    with pytest.raises(AssertionError, match=exp_error_msg):
+        await assert_metrics_endpoint(app, metrics_port=8000, metrics_path="/metrics")
+
+    mock_get_app_relation_data.assert_awaited_once_with(app, "metrics-endpoint")
+    mock_get_metrics_endpoint.assert_not_called()
+    mock_check_metrics_endpoint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("pytest_operator.cos._get_app_relation_data")
+@patch("pytest_operator.cos._get_metrics_endpoint")
+@patch("pytest_operator.cos._check_metrics_endpoint")
+async def test_assert_metrics_endpoint(
+    mock_check_metrics_endpoint, mock_get_metrics_endpoint, mock_get_app_relation_data
+):
+    """Test assert function for metrics endpoint."""
+    app = Mock(spec_set=Application)()
+    mock_get_app_relation_data.return_value = {"scrape_jobs": "..."}
+    mock_get_metrics_endpoint.return_value = {"*:5000/metrics"}
+
+    await assert_metrics_endpoint(app, metrics_port=5000, metrics_path="/metrics")
+
+    mock_get_app_relation_data.assert_awaited_once_with(app, "metrics-endpoint")
+    mock_get_metrics_endpoint.assert_called_once_with("...")
+    mock_check_metrics_endpoint.assert_awaited_once_with(app, "*:5000/metrics")
+
+
+@pytest.mark.asyncio
+@patch("pytest_operator.cos._get_app_relation_data")
+@patch("pytest_operator.cos._get_metrics_endpoint")
+@patch("pytest_operator.cos._check_metrics_endpoint")
+async def test_assert_metrics_endpoint_fail(
+    mock_check_metrics_endpoint, mock_get_metrics_endpoint, mock_get_app_relation_data
+):
+    """Test assert function for metrics endpoint failing."""
+    app = Mock(spec_set=Application)()
+    mock_get_app_relation_data.return_value = {"scrape_jobs": "..."}
+    mock_get_metrics_endpoint.return_value = {"*:5000/metrics"}
+
+    with pytest.raises(AssertionError):
+        await assert_metrics_endpoint(app, metrics_port=8000, metrics_path="/metrics")
+
+    mock_get_app_relation_data.assert_awaited_once_with(app, "metrics-endpoint")
+    mock_get_metrics_endpoint.assert_called_once_with("...")
+    mock_check_metrics_endpoint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("pytest_operator.cos._get_unit_relation_data")
+async def test_assert_logging(mock_get_unit_relation_data):
+    """Test assert function for logging endpoint."""
+    app = Mock(spec_set=Application)()
+    mock_get_unit_relation_data.return_value = {"my-app/0": {"endpoint": "..."}}
+
+    await assert_logging(app)
+
+    mock_get_unit_relation_data.assert_awaited_once_with(app, "logging")
+
+
+@pytest.mark.asyncio
+@patch("pytest_operator.cos._get_unit_relation_data")
+async def test_assert_logging_fail(mock_get_unit_relation_data):
+    """Test assert function for logging endpoint."""
+    app = Mock(spec_set=Application)()
+    mock_get_unit_relation_data.return_value = {"my-app/0": {}}
+
+    with pytest.raises(AssertionError):
+        await assert_logging(app)
+
+    mock_get_unit_relation_data.assert_awaited_once_with(app, "logging")
+
+
+def test_get_alert_rules(tmp_path):
+    """Test load alert rules from directory."""
+    exp_alert_rules = {"MyAlert1", "MyAlert2"}
+    # create two example file
+    (tmp_path / "test_cos_alert_rules.rules").write_text(MY_ALERT_1)
+    (tmp_path / "test_cos_alert_rules.rule").write_text(MY_ALERT_2)
+
+    assert get_alert_rules(tmp_path) == exp_alert_rules


### PR DESCRIPTION
This is part of Kubeflow enhancement to integrate observability to all charms (37). Since all tests will be the same in all charms, it makes sense to put them on one place.
This help to test integration of any k8s charm and grafana-agent-k8s charm, as it was discussed with observability team this is recommended way to test such integration. Deploying whole cos should not be necessary.

See the original implementation in Chisme [1].

---
[1]: https://github.com/canonical/charmed-kubeflow-chisme/pull/98