### PR TITLE
docs: fix reference docs link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ async def test_build_and_deploy(ops_test):
 
 ## Reference
 
-More details can be found in [the reference docs](docs/reference.md).
+More details can be found in [the reference docs](https://github.com/charmed-kubernetes/pytest-operator/blob/main/docs/reference.md).


### PR DESCRIPTION
Fix reference docs link in readme, so that it shows correctly on PyPI.

Since readme content is copied, PyPI doesn't know the base URL for the links in the readme file, and today pypi's link for "the reference docs" points to `https://pypi.org/project/pytest-operator/docs/reference.md` which doesn't exit.