### PR TITLE
Bump juju charm versions to follow 3/stable

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,10 +27,10 @@ jobs:
         juju: ['2.9']
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 
@@ -70,9 +70,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.10'
 
     - name: Setup operator test environment
       uses: charmed-kubernetes/actions-operator@main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        juju: ['3.1', '3.3']
+        juju: ['3.1', '3']
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Setup operator test environment
       uses: charmed-kubernetes/actions-operator@main

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -44,7 +44,7 @@ class TestPlugin:
         )
         log.info("Deploying bundle")
         await ops_test.model.deploy(bundle)
-        await ops_test.model.wait_for_idle()
+        await ops_test.model.wait_for_idle(timeout=30 * 60)
         for unit in ops_test.model.units.values():
             assert f"{unit.name}: {unit.workload_status}".endswith("active")
 


### PR DESCRIPTION
## Overview
Rather the follow a specific latest 3.* snap channel, just rolling pick the latest juju stable from the 3/stable branch

## Details
* ends testing of 3.3/stable juju specifically in favor of whatever is the most recent juju 3.* version
* update actions workflows
* provides more time for the setup of the models