### PR TITLE
Use sudo rather than sg on ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
     with:
-      python: "['3.8', '3.9', '3.10', '3.11']"
+      python: "['3.8', '3.9', '3.10', '3.11', '3.12']"
     needs:
       - call-inclusive-naming-check
 
@@ -60,10 +60,11 @@ jobs:
 
   integration-test:
     name: Integration test with juju
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-${{ matrix.ubuntu }}
     timeout-minutes: 40
     strategy:
       matrix:
+        ubuntu: ['20.04', '22.04', '24.04']
         juju: ['3.1', '3']
     steps:
     - name: Check out code

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -95,7 +95,7 @@ async def test_destructive_mode(monkeypatch, tmp_path_factory):
         # We didn't actually build it
         assert str(e).startswith("Failed to build charm")
     assert mock_run.called
-    assert mock_run.call_args[0] == ("sg", "lxd", "-c", "charmcraft pack")
+    assert mock_run.call_args[0] == ("sudo", "-g", "lxd", "-E", "charmcraft", "pack")
 
     mock_getgroups.return_value = [ANY]
     try:

--- a/tests/unit/test_pytest_operator.py
+++ b/tests/unit/test_pytest_operator.py
@@ -644,7 +644,8 @@ async def test_fixture_set_up_automatic_model(
 @pytest.mark.parametrize("model_name", [None, "alt-model"])
 @pytest.mark.parametrize("cloud_name", [None, "alt-cloud"])
 @pytest.mark.parametrize(
-    "block_exception", [None, asyncio.TimeoutError(), ConnectionClosed(1, "test")]
+    "block_exception",
+    [None, asyncio.TimeoutError(), ConnectionClosed(1, "test", False)],
 )
 @patch("pytest_operator.plugin.OpsTest.juju", autospec=True)
 async def test_fixture_create_remove_model(


### PR DESCRIPTION
### Overview

Addresses issue #139 on ubuntu-24.04 workers

### Details
* tests on broader versions of ubuntu runners
* fixes unit test issue created by newer websockets library


### Failing tests:
* the new ubuntu-24.04 tests fail because of https://github.com/charmed-kubernetes/actions-operator/issues/82 but i cannot fix it without this change first.  