### PR TITLE
feat: Adds charmcraft pack arguments

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -83,6 +83,16 @@ the current working directory.
 
 Maximum frame size to use when connecting to a juju model. The default is None
 
+### `--charmcraft-args`
+
+Extra set of arguments to pass to charmcraft when packing the charm
+* can be invoked multiple times to pass multiple arguments
+* example)
+```
+pytest ... \
+   --charmcraft-args '--platform=my-platform' \
+   --charmcraft-args '--verbosity=debug'
+```
 
 ## Fixtures
 

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -152,6 +152,12 @@ def pytest_addoption(parser: Parser):
         help="Set the maximum frame size for websocket communication with Juju.",
         type=int,
     )
+    parser.addoption(
+        "--charmcraft-args",
+        action="append",
+        help="Set extra charmcraft args.",
+        default=[],
+    )
 
 
 def pytest_load_initial_conftests(parser: Parser, args: List[str]) -> None:
@@ -531,6 +537,7 @@ class OpsTest:
         self._init_keep_model: bool = request.config.option.keep_models
         self._init_destroy_storage: bool = request.config.option.destroy_storage
         self._juju_connect_kwds: Dict[str, Any] = _connect_kwds(request)
+        self._charmcraft_args: List[str] = request.config.option.charmcraft_args
 
         # These may be modified by _setup_model
         self.controller_name = request.config.option.controller
@@ -1148,6 +1155,8 @@ class OpsTest:
                 cmd.append(f"--bases-index={bases_index}")
             if verbosity:
                 cmd.append(f"--verbosity={verbosity}")
+            for args in self._charmcraft_args:
+                cmd.append(args)
             if self.destructive_mode:
                 # host builder never requires lxd group
                 cmd.append("--destructive-mode")

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(include=["pytest_operator"]),
     package_data={"pytest_operator": ["py.typed"]},
     url="https://github.com/charmed-kubernetes/pytest-operator",
-    version="0.39.0",
+    version="0.40.0",
     zip_safe=True,
     install_requires=[
         "ipdb",


### PR DESCRIPTION
Allows one to direct pytest to run with new arguments for charmcraft
* `--charmcraft-args` can be used multiple times to pass extra args to charmcraft
