### PR TITLE
Support for multiple charm files outputs during charmcraft pack

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -231,14 +231,17 @@ Dataclass which represents a juju bundle.
 
 ### Methods
 
-#### `async def build_charm(self, charm_path, bases_index = None, verbosity = None)`
+#### `async def build_charm(self, charm_path, bases_index = None, verbosity = None, allow_all=False)`
 
 Builds a charm.
 
 This can handle charms using the older charms.reactive framework as well as charms
 written against the modern operator framework.
 
-Returns a `pathlib.Path` for the built charm file.
+Returns a `pathlib.Path` for the built charm file if `allow_all` is `False`
+Returns a `List[pathlib.Path]` for the built charms if `allow_all` is `True`
+Raises a `FileNotFound` exception if no charms are found after a successful build.
+
 
 #### `async def build_charms(self, *charm_paths)`
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -231,7 +231,7 @@ Dataclass which represents a juju bundle.
 
 ### Methods
 
-#### `async def build_charm(self, charm_path, bases_index = None, verbosity = None, return_all=False)`
+#### `async def build_charm(self, charm_path, bases_index = None, verbosity = None, return_all = False)`
 
 Builds a charm.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -231,16 +231,17 @@ Dataclass which represents a juju bundle.
 
 ### Methods
 
-#### `async def build_charm(self, charm_path, bases_index = None, verbosity = None, allow_all=False)`
+#### `async def build_charm(self, charm_path, bases_index = None, verbosity = None, return_all=False)`
 
 Builds a charm.
 
 This can handle charms using the older charms.reactive framework as well as charms
 written against the modern operator framework.
 
-Returns a `pathlib.Path` for the built charm file if `allow_all` is `False`
-Returns a `List[pathlib.Path]` for the built charms if `allow_all` is `True`
+Returns a `pathlib.Path` for the built charm file if `return_all` is `False`
+Returns a `List[pathlib.Path]` for the built charms if `return_all` is `True`
 Raises a `FileNotFound` exception if no charms are found after a successful build.
+Raises a `RuntimeError` exception if the charm build fails.
 
 
 #### `async def build_charms(self, *charm_paths)`

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -1110,7 +1110,7 @@ class OpsTest:
         verbosity: Optional[
             Literal["quiet", "brief", "verbose", "debug", "trace"]
         ] = None,
-        return_all: Literal[False] = False,
+        return_all: Literal[False] = False,  # default case first
     ) -> Path: ...
 
     @overload

--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -34,6 +34,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    overload,
 )
 from urllib.error import HTTPError
 from urllib.parse import urlencode
@@ -1101,6 +1102,28 @@ class OpsTest:
         self.aborted = True
         pytest.fail(*args, **kwargs)
 
+    @overload
+    async def build_charm(
+        self,
+        charm_path,
+        bases_index: Optional[int] = None,
+        verbosity: Optional[
+            Literal["quiet", "brief", "verbose", "debug", "trace"]
+        ] = None,
+        return_all: Literal[False] = False,
+    ) -> Path: ...
+
+    @overload
+    async def build_charm(
+        self,
+        charm_path,
+        bases_index: Optional[int] = None,
+        verbosity: Optional[
+            Literal["quiet", "brief", "verbose", "debug", "trace"]
+        ] = None,
+        return_all: Literal[True] = True,
+    ) -> List[Path]: ...
+
     async def build_charm(
         self,
         charm_path,
@@ -1108,7 +1131,7 @@ class OpsTest:
         verbosity: Optional[
             Literal["quiet", "brief", "verbose", "debug", "trace"]
         ] = None,
-        allow_all: bool = False,
+        return_all: bool = False,
     ) -> Union[Path, List[Path]]:
         """Builds a single charm.
 
@@ -1120,7 +1143,7 @@ class OpsTest:
             bases_index: Index of `bases` configuration to build
                          (see charmcraft pack help)
             verbosity:   Verbosity level for charmcraft pack.
-            allow_all:   Return all built charms, not just the first one.
+            return_all:  Return all built charms, not just the first one.
 
         Returns:
             Returns a Path / Paths for the built charm file.
@@ -1215,7 +1238,7 @@ class OpsTest:
 
         if not charms:
             raise FileNotFoundError(f"No such file in '{charm_path}/*.charm'")
-        if charms and not allow_all:
+        if charms and not return_all:
             # Even though we may have multiple *.charm file,
             # for backwards compatibility we can - only return one.
             return charms[0]

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(include=["pytest_operator"]),
     package_data={"pytest_operator": ["py.typed"]},
     url="https://github.com/charmed-kubernetes/pytest-operator",
-    version="0.40.0",
+    version="0.41.0",
     zip_safe=True,
     install_requires=[
         "ipdb",


### PR DESCRIPTION
### Overview

`charmcraft pack` can yield multiple charm files in the event there are multiple runs on or multiple platforms. 

By passing `return_all=True`, the `build_charm` method returns a list of those paths. 

