### PR TITLE
feat: Always restore slow interval after fast-forward

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -1645,9 +1645,12 @@ class OpsTest:
         else:
             interval_after = (await model.get_config())[update_interval_key]
 
-        await model.set_config({update_interval_key: fast_interval})
-        yield
-        await model.set_config({update_interval_key: interval_after})
+        try:
+            await model.set_config({update_interval_key: fast_interval})
+            yield
+        finally:
+            # Whatever happens, we restore the interval.
+            await model.set_config({update_interval_key: interval_after})
 
     def is_crash_dump_enabled(self) -> bool:
         """Returns whether Juju crash dump is enabled given the current settings."""

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(include=["pytest_operator"]),
     package_data={"pytest_operator": ["py.typed"]},
     url="https://github.com/charmed-kubernetes/pytest-operator",
-    version="0.41.0",
+    version="0.42.0",
     zip_safe=True,
     install_requires=[
         "ipdb",

--- a/tests/integration/test_pytest_operator.py
+++ b/tests/integration/test_pytest_operator.py
@@ -156,6 +156,34 @@ async def test_fast_forward(ops_test: OpsTest, fast_interval, slow_interval):
     assert await _get_rate() == slow_interval or previous_rate
 
 
+@pytest.mark.parametrize(
+    "fast_interval, slow_interval",
+    (
+        ("10s", None),
+        ("10s", "10m"),
+        ("42s", "42m"),
+        ("41m", "41s"),  # odd but... why not.
+        ("43s", None),
+    ),
+)
+async def test_fast_forward_with_exception(
+    ops_test: OpsTest, fast_interval, slow_interval
+):
+    async def _get_rate():
+        return (await ops_test.model.get_config())["update-status-hook-interval"].value
+
+    previous_rate = await _get_rate()
+
+    with pytest.raises(ValueError):
+        async with ops_test.fast_forward(
+            fast_interval=fast_interval, slow_interval=slow_interval
+        ):
+            assert await _get_rate() == fast_interval
+            raise ValueError
+
+    assert await _get_rate() == slow_interval or previous_rate
+
+
 @pytest.mark.abort_on_fail(abort_on_xfail=True)
 def test_abort():
     pytest.xfail("abort")


### PR DESCRIPTION
The current implementation of fast-forward fails to restore the slow interval if an exception was raised in the context manager.

 This implementation is safer in that regard as it will restore the slow interval no matter what.

Closes: #137 