### PR TITLE
improve build_charm failure logs

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -1226,7 +1226,10 @@ class OpsTest:
                 except FileNotFoundError:
                     log.error(f"Failed to read full build log from {m.group(1)}")
             raise RuntimeError(
-                f"Failed to build charm {charm_path}:\n{stderr}\n{stdout}"
+                f"Failed to build charm at path `{charm_path}`:\n"
+                f"    command used: `{' '.join(cmd)}`\n"
+                f"    stdout: {stdout or '(null)'}\n"
+                f"    stderr: {stderr or '(null)'}\n"
             )
 
         # If charmcraft.yaml has multiple bases


### PR DESCRIPTION
The logs when build_charm fails are currently unclear. For example, in the context of a `tox` integration test:

![image](https://github.com/user-attachments/assets/6b216918-4aae-4b3d-8286-1aa361fcfa6b)

It is not clear that the final line of output is the stderr of the charm-building command, nor is it clear what command was used to attempt building the charm. It is rather difficult to troubleshoot starting from just this information.

With the suggested changes, it is considerably easier to get started with troubleshooting:

![image](https://github.com/user-attachments/assets/650ab7a8-7862-41a7-b0f9-38ab6a2d86f6)
