### PR TITLE
fix: cloud entries in an dictionary were being deleted while iterating the object

### DIFF
--- a/pytest_operator/plugin.py
+++ b/pytest_operator/plugin.py
@@ -1089,12 +1089,11 @@ class OpsTest:
     async def _cleanup_models(self):
         # remove clouds from most recently made, to first made
         # each model in the cloud will be forgotten
-        for cloud in reversed(self._clouds):
+        for cloud in list(reversed(self._clouds)):
             await self.forget_cloud(cloud)
 
         # remove models from most recently made, to first made
-        aliases = list(reversed(self._models.keys()))
-        for model in aliases:
+        for model in list(reversed(self._models)):
             await self.forget_model(model)
 
         await self._controller.disconnect()


### PR DESCRIPTION
Found in a PR where multiple kubernetes clouds were created by pytest_operator atop an existing machine cloud. 

When cleaning up the created clouds, we deleted an entry in `self.forget_cloud(...)`  that was maintained by `self._clouds`

this results in an exception:

```
  File "/home/ubuntu/actions-runner/_work/k8s-operator/k8s-operator/.tox/integration/lib/python3.12/site-packages/pytest_operator/plugin.py", line 1092, in _cleanup_models
    for cloud in reversed(self._clouds):
RuntimeError: OrderedDict mutated during iteration
```

The correct behavior is to operate on an inline list instead of iterating the dict itself.